### PR TITLE
Comprehensive refactoring: security, DRY, features (28 issues)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,21 @@
+# Environment
+.env
+.env.*
+!.env.example
+
+# Editor swap files
+*.swp
+*.swo
+*~
+
+# IDE directories
+.vscode/
+.idea/
+
+# OS metadata
+.DS_Store
+Thumbs.db
+
+# Credentials
+*.pem
+*.key

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,9 +9,25 @@
 ## Workflow
 
 1. Änderungen im Repo machen (`/home/rob/bpm-SecureShellManager/sm`)
-2. Nach Installation kopieren: `cp sm ~/.local/bin/sm`
-   - Oder `./install.sh` nutzen
+2. Installieren: `./install.sh --user` (brennt Version ein)
+   - Alternativ: `cp sm ~/.local/bin/sm` (zeigt dann "dev")
 3. Commit & Push
+
+## Versioning
+
+Format: **YYMMDD-HHMM** (Zeitstempel des HEAD-Commits)
+
+| Zustand | Anzeige | Bedeutung |
+|---------|---------|-----------|
+| committed + pushed | `260214-1154` | Release — produktionsbereit |
+| committed + nicht gepusht | `260214-1154-draft` | Push steht noch aus |
+| uncommitted changes | `260214-1154-dirty` | Noch nicht committed |
+| Kein Git-Repo (plain copy) | `dev` | Nicht über install.sh installiert |
+
+- `sm --version` zeigt den Zustand live (wenn aus Git-Repo ausgeführt)
+- `install.sh` brennt den aktuellen Zustand als fixen String ein
+- Rollback: `cp ~/.local/bin/sm.bak ~/.local/bin/sm`
+- **Immer `install.sh --user` statt `cp` verwenden** — sonst fehlt die Version
 
 ## Git Identity
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,13 +15,13 @@
 
 ## Versioning
 
-Format: **YYMMDD-HHMM** (Zeitstempel des HEAD-Commits)
+Format: **YYMMDD-HHMM**
 
-| Zustand | Anzeige | Bedeutung |
-|---------|---------|-----------|
-| committed + pushed | `260214-1154` | Release — produktionsbereit |
-| committed + nicht gepusht | `260214-1154-draft` | Push steht noch aus |
-| uncommitted changes | `260214-1154-dirty` | Noch nicht committed |
+| Zustand | Anzeige | Zeitstempel | Bedeutung |
+|---------|---------|-------------|-----------|
+| committed + pushed | `260214-1154` | HEAD-Commit | Release — produktionsbereit |
+| committed + nicht gepusht | `260214-1154-draft` | HEAD-Commit | Push steht noch aus |
+| uncommitted changes | `260217-0930-dirty` | **Install-Zeitpunkt** | Noch nicht committed |
 | Kein Git-Repo (plain copy) | `dev` | Nicht über install.sh installiert |
 
 - `sm --version` zeigt den Zustand live (wenn aus Git-Repo ausgeführt)

--- a/README.md
+++ b/README.md
@@ -79,6 +79,18 @@ export PATH="$HOME/.local/bin:$PATH"
 | `sm <alias>` | Direkt zu Verbindung verbinden |
 | `sm list` | Alle Verbindungen anzeigen |
 | `sm set <alias>` | Default-Verbindung setzen |
+| `sm edit` | Config in $EDITOR öffnen |
+| `sm test <alias>` | SSH-Konnektivität testen |
+| `sm validate` | Config-Datei validieren |
+| `sm auth <alias>` | Verbinden mit Auth Port Forwarding (1455) |
+| `sm parallel <alias>` | Neue parallele Session erstellen |
+| `sm reset <alias>` | Hard Reset (Sessions löschen und neu) |
+| `sm sessions <alias>` | Sessions auf Server auflisten |
+| `sm add` | Neue Verbindung hinzufügen (Wizard) |
+| `sm remove <alias>` | Verbindung entfernen |
+| `sm completions [bash\|zsh]` | Shell-Completions ausgeben |
+| `sm --help` | Hilfe anzeigen |
+| `sm --version` | Version anzeigen |
 | `smd` | Schnellzugriff auf Default |
 | `sml` | Sessions auf Default-Server auflisten |
 
@@ -86,35 +98,58 @@ export PATH="$HOME/.local/bin:$PATH"
 
 ```
 === SM - SSH Manager ===
-ALIAS      HOSTALIAS    USER            DIRECTORY
+ALIAS      HOSTALIAS    USER            DIRECTORY     DESCRIPTION
 --------------------------------------------------------------------------------
-> sm231    contabo2     rob-ico         ico-n8n-prozesse2
-  sm232    contabo2     rob-ico         ico-cert
+> sm231    contabo2     rob-ico         ico-n8n       N8N Server
+  sm232    contabo2     rob-ico         ico-cert      Cert Service
 
-↑↓ Navigate | Enter: Connect | A: Auth | P: Parallel | L: List | H: Hard Reset | D: Default | Q: Exit
+↑↓ Navigate | Enter: Connect | /: Search | A: Auth | P: Parallel | L: List | H: Hard Reset | D: Default | Q: Exit
 ```
 
-**Tastenbelegung:**
-- `↑↓` - Navigation
-- `Enter` - Verbinden (zellij Session wiederherstellen/erstellen)
-- `A` - Auth Mode (SSH mit Port 1455 Forwarding)
-- `P` - Parallele Session erstellen (alias_2, alias_3, ...)
-- `L` - Sessions auf Server auflisten und auswählen
-- `H` - Hard Reset (Session löschen und neu erstellen)
-- `D` - Als Default setzen
-- `Esc/Q` - Beenden
+**Tastenbelegung Hauptmenü:**
+
+| Taste | Beschreibung |
+|-------|--------------|
+| `↑↓` | Navigation (mit Wrap-Around) |
+| `Enter` | Verbinden (zellij Session wiederherstellen/erstellen) |
+| `/` | Suchfilter aktivieren (tippt zum Filtern) |
+| `A` | Auth Mode (SSH mit Port 1455 Forwarding) |
+| `P` | Parallele Session erstellen (alias_2, alias_3, ...) |
+| `L` | Sessions auf Server auflisten und auswählen |
+| `H` | Hard Reset (Session löschen und neu erstellen) |
+| `D` | Als Default setzen |
+| `Esc/Q` | Beenden |
+
+**Tastenbelegung Suchfilter (nach `/`):**
+
+| Taste | Beschreibung |
+|-------|--------------|
+| Buchstaben/Zahlen | Zum Filter hinzufügen |
+| `Backspace` | Letztes Zeichen löschen |
+| `↑↓` | Navigation in gefilterten Ergebnissen |
+| `Enter` | Zum ausgewählten Eintrag verbinden |
+| `Esc` | Filter löschen, zurück zum Hauptmenü |
 
 ### Session-Liste (L)
 
 ```
-=== Sessions on sm210 (N8N Prozesse) ===
+=== Sessions for sm210 (N8N Prozesse) ===
 
-> sm210 [Created 5m ago]
-  sm220 [Created 1h ago]
-  [NEW] Create session 'sm210'
+> sm210
+  sm210_2
+  [NEW] Create parallel session
 
-↑↓ Navigate | Enter: Connect | Esc/Q: Back
+↑↓ Navigate | Enter: Connect | H: Hard Reset | Q: Back
 ```
+
+**Tastenbelegung Session-Liste:**
+
+| Taste | Beschreibung |
+|-------|--------------|
+| `↑↓` | Navigation |
+| `Enter` | Zur ausgewählten Session verbinden |
+| `H` | Hard Reset der ausgewählten Session |
+| `Esc/Q` | Zurück zum Hauptmenü |
 
 ## Session-Persistenz
 
@@ -169,9 +204,22 @@ sm232|contabo2.example.com|22|rob-ico|ico-cert|Cert Service|~/.ssh/special_key
 # Host-Alias (optional):
 hostalias:contabo2.example.com=contabo2
 
+# Connection groups (optional):
+# group: Production
+sm231|prod1.example.com|22|admin|/app|Prod Server 1|
+# group: Staging
+sm232|staging.example.com|22|admin|/app|Staging Server|
+
 # Default-Verbindung:
 default=sm231
 ```
+
+### Optionen
+
+| Option | Beschreibung |
+|--------|--------------|
+| `--no-color` | Farbige Ausgabe deaktivieren |
+| `NO_COLOR=1` | Umgebungsvariable zum Deaktivieren der Farben |
 
 ### Felder
 

--- a/install.sh
+++ b/install.sh
@@ -76,14 +76,17 @@ install_to() {
         install_type="Update"
     fi
 
-    # Stamp version from HEAD commit date (installed copy has no git repo)
+    # Stamp version: dirty uses install timestamp, clean uses commit timestamp
     local ver="" suffix=""
     if [[ -n "$SCRIPT_DIR" ]] && git -C "$SCRIPT_DIR" rev-parse --git-dir &>/dev/null; then
-        ver=$(git -C "$SCRIPT_DIR" log -1 --format='%cd' --date=format:'%y%m%d-%H%M' HEAD 2>/dev/null || echo "")
         if ! git -C "$SCRIPT_DIR" diff --quiet HEAD 2>/dev/null || ! git -C "$SCRIPT_DIR" diff --cached --quiet HEAD 2>/dev/null; then
+            ver=$(date '+%y%m%d-%H%M')
             suffix="-dirty"
         elif ! git -C "$SCRIPT_DIR" diff --quiet HEAD "@{upstream}" 2>/dev/null; then
+            ver=$(git -C "$SCRIPT_DIR" log -1 --format='%cd' --date=format:'%y%m%d-%H%M' HEAD 2>/dev/null || echo "")
             suffix="-draft"
+        else
+            ver=$(git -C "$SCRIPT_DIR" log -1 --format='%cd' --date=format:'%y%m%d-%H%M' HEAD 2>/dev/null || echo "")
         fi
     fi
 

--- a/install.sh
+++ b/install.sh
@@ -18,6 +18,7 @@ if [[ -n "${BASH_SOURCE[0]:-}" ]]; then
     SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd 2>/dev/null || echo "")"
 fi
 LOCAL_SM="${SCRIPT_DIR:+${SCRIPT_DIR}/sm}"
+LOCAL_SM2="${SCRIPT_DIR:+${SCRIPT_DIR}/sm2}"
 
 # Parse arguments
 MODE=""
@@ -66,19 +67,14 @@ install_to() {
 
     mkdir -p "$dir"
 
-    # Check for existing installation
-    if [[ -f "${dir}/sm" ]]; then
+    # Check for existing installation (check sm2 first since sm may be a symlink)
+    if [[ -f "${dir}/sm2" ]]; then
+        old_version=$(get_sm_version "${dir}/sm2")
+        install_type="Update"
+    elif [[ -f "${dir}/sm" && ! -L "${dir}/sm" ]]; then
         old_version=$(get_sm_version "${dir}/sm")
         install_type="Update"
     fi
-
-    # Install new version
-    if [[ -n "$SCRIPT_DIR" && -f "$LOCAL_SM" ]]; then
-        cp "$LOCAL_SM" "${dir}/sm"
-    else
-        curl -fsSL -o "${dir}/sm" "${BASE_URL}/sm"
-    fi
-    chmod +x "${dir}/sm"
 
     # Stamp version from HEAD commit date (installed copy has no git repo)
     local ver="" suffix=""
@@ -90,14 +86,40 @@ install_to() {
             suffix="-draft"
         fi
     fi
-    if [[ -n "$ver" ]]; then
-        sed -i "0,/^SM_VERSION=/{s/^SM_VERSION=.*/SM_VERSION=\"${ver}${suffix}\"/}" "${dir}/sm"
+
+    # Install sm1 (Zellij legacy)
+    if [[ -n "$SCRIPT_DIR" && -f "$LOCAL_SM" ]]; then
+        cp "$LOCAL_SM" "${dir}/sm1"
+    else
+        curl -fsSL -o "${dir}/sm1" "${BASE_URL}/sm"
     fi
-    ln -sf "${dir}/sm" "${dir}/smd"
-    ln -sf "${dir}/sm" "${dir}/sml"
+    chmod +x "${dir}/sm1"
+    if [[ -n "$ver" ]]; then
+        sed -i "0,/^SM_VERSION=/{s/^SM_VERSION=.*/SM_VERSION=\"${ver}${suffix}\"/}" "${dir}/sm1"
+    fi
+    ln -sf "${dir}/sm1" "${dir}/sm1d"
+    ln -sf "${dir}/sm1" "${dir}/sm1l"
+
+    # Install sm2 (tmux, default)
+    if [[ -n "$SCRIPT_DIR" && -f "$LOCAL_SM2" ]]; then
+        cp "$LOCAL_SM2" "${dir}/sm2"
+    else
+        curl -fsSL -o "${dir}/sm2" "${BASE_URL}/sm2"
+    fi
+    chmod +x "${dir}/sm2"
+    if [[ -n "$ver" ]]; then
+        sed -i "0,/^SM_VERSION=/{s/^SM_VERSION=.*/SM_VERSION=\"${ver}${suffix}\"/}" "${dir}/sm2"
+    fi
+    ln -sf "${dir}/sm2" "${dir}/sm2d"
+    ln -sf "${dir}/sm2" "${dir}/sm2l"
+
+    # sm/smd/sml → sm2 (tmux is the new default)
+    ln -sf "${dir}/sm2" "${dir}/sm"
+    ln -sf "${dir}/sm2" "${dir}/smd"
+    ln -sf "${dir}/sm2" "${dir}/sml"
 
     # Get new version
-    new_version=$(get_sm_version "${dir}/sm")
+    new_version=$(get_sm_version "${dir}/sm2")
 
     # Display result
     if [[ "$install_type" == "Update" ]]; then
@@ -139,4 +161,6 @@ case "$MODE" in
 esac
 
 echo ""
-echo "Commands: sm, smd (default), sml (list)"
+echo "Commands: sm, smd, sml          → tmux (default)"
+echo "         sm2, sm2d, sm2l        → tmux (explicit)"
+echo "         sm1, sm1d, sm1l        → Zellij (legacy)"

--- a/sm
+++ b/sm
@@ -31,6 +31,11 @@ YELLOW='\033[1;33m'
 BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 
+# Escape string for use in regex patterns (grep -E, bash [[ =~ ]])
+regex_escape() {
+    printf '%s' "$1" | sed 's/[][\\.^$*+?(){}|]/\\&/g'
+}
+
 # Set terminal window title (user@hostalias - description)
 set_terminal_title() {
     printf '\033]0;%s\007' "$1"
@@ -66,11 +71,11 @@ ZELLIJ_MOUSE_FIX=''
 
 # rmate reverse port forwarding (allows editing remote files with local editor)
 # Usage on server: rmate filename.txt
-RMATE_FORWARD='-R 52698:localhost:52698'
+RMATE_FORWARD=(-R 52698:localhost:52698)
 
 # SSH timeout for session queries (seconds) - prevents hanging after host reboot
 # ConnectTimeout: TCP connect phase. Local timeout wrapper: covers remote command hangs too.
-SSH_QUERY_TIMEOUT='-o ConnectTimeout=5 -o ServerAliveInterval=3 -o ServerAliveCountMax=2'
+SSH_QUERY_TIMEOUT_OPTS=(-o ConnectTimeout=5 -o ServerAliveInterval=3 -o ServerAliveCountMax=2)
 SSH_QUERY_MAX_SECS=10  # hard kill for entire ssh query call
 
 # Initialize config if not exists
@@ -101,6 +106,17 @@ EOF
     fi
 }
 
+# Validate port number (1-65535)
+validate_port() {
+    local port="$1"
+    local alias="$2"
+    if [[ -z "$port" ]] || [[ ! "$port" =~ ^[0-9]+$ ]] || [[ "$port" -lt 1 ]] || [[ "$port" -gt 65535 ]]; then
+        echo -e "${RED}Error: Invalid port '${port}' for connection '${alias}' (must be 1-65535)${NC}" >&2
+        return 1
+    fi
+    return 0
+}
+
 # Get default connection
 get_default() {
     grep "^default=" "$CONFIG_FILE" 2>/dev/null | cut -d'=' -f2 | tr -d ' ' || echo ""
@@ -109,9 +125,10 @@ get_default() {
 # Get host alias for a hostname
 get_host_alias() {
     local hostname="$1"
-    local alias_line=$(grep "^hostalias:${hostname}=" "$CONFIG_FILE" 2>/dev/null || echo "")
+    local alias_line
+    alias_line=$(awk -F'=' -v key="hostalias:${hostname}" '$1 == key {print substr($0, length($1)+2)}' "$CONFIG_FILE" 2>/dev/null || echo "")
     if [[ -n "$alias_line" ]]; then
-        echo "${alias_line#*=}"
+        echo "$alias_line"
     else
         echo ""
     fi
@@ -340,7 +357,7 @@ set_default() {
     local new_default="$1"
 
     # Check if connection exists
-    if ! grep -q "^${new_default}|" "$CONFIG_FILE"; then
+    if ! awk -F'|' -v key="$new_default" '$1 == key {found=1; exit} END {exit !found}' "$CONFIG_FILE"; then
         echo -e "${RED}Error: Connection '$new_default' not found${NC}"
         exit 1
     fi
@@ -360,29 +377,34 @@ set_default() {
 # Runs locally - queries remote server via SSH
 get_sessions_for_alias() {
     local alias="$1"
-    local ssh_cmd="$2"
+    shift
+    local ssh_cmd=("$@")
+    local safe_alias
+    safe_alias=$(regex_escape "$alias")
+    # Build timeout command array
+    local ssh_cmd_timeout=("${ssh_cmd[0]}" "${SSH_QUERY_TIMEOUT_OPTS[@]}" "${ssh_cmd[@]:1}")
     # Get sessions from remote, strip ANSI codes, filter by alias pattern
-    # Insert timeout options and wrap with local timeout to prevent hanging
-    local ssh_cmd_timeout="${ssh_cmd/ssh/ssh $SSH_QUERY_TIMEOUT}"
-    timeout "$SSH_QUERY_MAX_SECS" $ssh_cmd_timeout "zellij list-sessions 2>/dev/null" 2>/dev/null | \
+    timeout "$SSH_QUERY_MAX_SECS" "${ssh_cmd_timeout[@]}" "zellij list-sessions 2>/dev/null" 2>/dev/null | \
         sed 's/\x1b\[[0-9;]*m//g' | \
-        grep -E "^${alias}(_[0-9]+)?(\s|$)" | \
+        grep -E "^${safe_alias}(_[0-9]+)?(\s|$)" | \
         awk '{print $1}'
 }
 
 # Count sessions for an alias
 count_sessions_for_alias() {
     local alias="$1"
-    local ssh_cmd="$2"
-    get_sessions_for_alias "$alias" "$ssh_cmd" | wc -l
+    shift
+    local ssh_cmd=("$@")
+    get_sessions_for_alias "$alias" "${ssh_cmd[@]}" | wc -l
 }
 
 # Get next parallel session name
 get_next_session_name() {
     local alias="$1"
-    local ssh_cmd="$2"
+    shift
+    local ssh_cmd=("$@")
     local sessions
-    sessions=$(get_sessions_for_alias "$alias" "$ssh_cmd")
+    sessions=$(get_sessions_for_alias "$alias" "${ssh_cmd[@]}")
     local count
     count=$(echo "$sessions" | grep -c . || echo "0")
 
@@ -404,23 +426,29 @@ get_next_session_name() {
 # Check if a specific session is exited/dead
 is_session_exited() {
     local session="$1"
-    local ssh_cmd="$2"
-    local ssh_cmd_timeout="${ssh_cmd/ssh/ssh $SSH_QUERY_TIMEOUT}"
-    timeout "$SSH_QUERY_MAX_SECS" $ssh_cmd_timeout "zellij list-sessions 2>/dev/null" 2>/dev/null | grep -q "^${session}.*EXITED"
+    shift
+    local ssh_cmd=("$@")
+    local safe_session
+    safe_session=$(regex_escape "$session")
+    local ssh_cmd_timeout=("${ssh_cmd[0]}" "${SSH_QUERY_TIMEOUT_OPTS[@]}" "${ssh_cmd[@]:1}")
+    timeout "$SSH_QUERY_MAX_SECS" "${ssh_cmd_timeout[@]}" "zellij list-sessions 2>/dev/null" 2>/dev/null | grep -Eq "^${safe_session}.*EXITED"
 }
 
 # Cleanup dead/exited sessions for an alias
 cleanup_dead_sessions() {
     local alias="$1"
-    local ssh_cmd="$2"
-    local ssh_cmd_timeout="${ssh_cmd/ssh/ssh $SSH_QUERY_TIMEOUT}"
+    shift
+    local ssh_cmd=("$@")
+    local safe_alias
+    safe_alias=$(regex_escape "$alias")
+    local ssh_cmd_timeout=("${ssh_cmd[0]}" "${SSH_QUERY_TIMEOUT_OPTS[@]}" "${ssh_cmd[@]:1}")
     local sessions
-    sessions=$(timeout "$SSH_QUERY_MAX_SECS" $ssh_cmd_timeout "zellij list-sessions 2>/dev/null" 2>/dev/null | sed 's/\x1b\[[0-9;]*m//g')
+    sessions=$(timeout "$SSH_QUERY_MAX_SECS" "${ssh_cmd_timeout[@]}" "zellij list-sessions 2>/dev/null" 2>/dev/null | sed 's/\x1b\[[0-9;]*m//g')
 
     while IFS= read -r line; do
-        if [[ "$line" =~ ^(${alias}(_[0-9]+)?).*EXITED ]]; then
+        if [[ "$line" =~ ^(${safe_alias}(_[0-9]+)?).*EXITED ]]; then
             local dead_session="${BASH_REMATCH[1]}"
-            timeout "$SSH_QUERY_MAX_SECS" $ssh_cmd_timeout "zellij delete-session ${dead_session} --force 2>/dev/null" 2>/dev/null || true
+            timeout "$SSH_QUERY_MAX_SECS" "${ssh_cmd_timeout[@]}" "zellij delete-session ${dead_session} --force 2>/dev/null" 2>/dev/null || true
         fi
     done <<< "$sessions"
 }
@@ -428,13 +456,14 @@ cleanup_dead_sessions() {
 # Delete all sessions for an alias
 delete_all_sessions_for_alias() {
     local alias="$1"
-    local ssh_cmd="$2"
-    local ssh_cmd_timeout="${ssh_cmd/ssh/ssh $SSH_QUERY_TIMEOUT}"
+    shift
+    local ssh_cmd=("$@")
+    local ssh_cmd_timeout=("${ssh_cmd[0]}" "${SSH_QUERY_TIMEOUT_OPTS[@]}" "${ssh_cmd[@]:1}")
     local sessions
-    sessions=$(get_sessions_for_alias "$alias" "$ssh_cmd")
+    sessions=$(get_sessions_for_alias "$alias" "${ssh_cmd[@]}")
 
     while IFS= read -r session; do
-        [[ -n "$session" ]] && $ssh_cmd_timeout "zellij delete-session ${session} --force 2>/dev/null" 2>/dev/null || true
+        [[ -n "$session" ]] && "${ssh_cmd_timeout[@]}" "zellij delete-session ${session} --force 2>/dev/null" 2>/dev/null || true
     done <<< "$sessions"
 }
 
@@ -447,8 +476,9 @@ list_and_connect() {
     local stay_interactive=0
     [[ "${INTERACTIVE_MODE:-0}" -eq 1 ]] && stay_interactive=1
 
-    # Parse connection
-    local line=$(grep "^${alias}|" "$CONFIG_FILE" 2>/dev/null || echo "")
+    # Parse connection (awk for exact field match — no regex injection)
+    local line
+    line=$(awk -F'|' -v key="$alias" '$1 == key' "$CONFIG_FILE" 2>/dev/null || echo "")
 
     if [[ -z "$line" ]]; then
         echo -e "${RED}Error: Connection '$alias' not found${NC}"
@@ -461,29 +491,34 @@ list_and_connect() {
 
     IFS='|' read -r _ host port user directory description key <<< "$line"
 
-    # Build SSH command (base without auth port)
-    local ssh_cmd="ssh"
-    if [[ -n "$key" ]]; then
-        ssh_cmd="$ssh_cmd -i $key"
+    # Validate port
+    if ! validate_port "$port" "$alias"; then
+        if [[ $stay_interactive -eq 1 ]]; then
+            return 1
+        else
+            exit 1
+        fi
     fi
-    ssh_cmd="$ssh_cmd $RMATE_FORWARD -p $port ${user}@${host}"
 
-    # Build SSH command with auth port if needed
-    local ssh_cmd_auth="ssh"
-    if [[ -n "$key" ]]; then
-        ssh_cmd_auth="$ssh_cmd_auth -i $key"
-    fi
-    ssh_cmd_auth="$ssh_cmd_auth -L 1455:localhost:1455 $RMATE_FORWARD -p $port ${user}@${host}"
+    # Build SSH command array (base without auth port)
+    local ssh_cmd=(ssh)
+    [[ -n "$key" ]] && ssh_cmd+=(-i "$key")
+    ssh_cmd+=("${RMATE_FORWARD[@]}" -p "$port" "${user}@${host}")
+
+    # Build SSH command array with auth port if needed
+    local ssh_cmd_auth=(ssh)
+    [[ -n "$key" ]] && ssh_cmd_auth+=(-i "$key")
+    ssh_cmd_auth+=(-L 1455:localhost:1455 "${RMATE_FORWARD[@]}" -p "$port" "${user}@${host}")
 
     local cd_cmd=""
-    [[ -n "$directory" ]] && cd_cmd="cd $directory 2>/dev/null; "
+    [[ -n "$directory" ]] && cd_cmd="cd \"${directory}\" 2>/dev/null; "
 
     echo -e "${GREEN}=== Sessions on $alias ($description) ===${NC}"
     echo -e "${YELLOW}Fetching sessions...${NC}"
 
     # Get sessions from server (strip ANSI color codes) - filter by alias pattern
     local sessions
-    sessions=$(get_sessions_for_alias "$alias" "$ssh_cmd")
+    sessions=$(get_sessions_for_alias "$alias" "${ssh_cmd[@]}")
 
     if [[ -z "$sessions" ]]; then
         echo -e "${RED}No sessions found for '$alias'.${NC}"
@@ -501,10 +536,10 @@ list_and_connect() {
                 exit 0
             fi
         fi
-        local final_ssh="$ssh_cmd"
-        [[ "$auth_mode" == "auth" ]] && final_ssh="$ssh_cmd_auth"
+        local final_ssh=("${ssh_cmd[@]}")
+        [[ "$auth_mode" == "auth" ]] && final_ssh=("${ssh_cmd_auth[@]}")
         set_terminal_title "$(build_connection_title "$user" "$host" "$description")"
-        $final_ssh -t "${ZELLIJ_MOUSE_FIX}${cd_cmd}zellij attach -c ${alias}"
+        "${final_ssh[@]}" -t "${ZELLIJ_MOUSE_FIX}${cd_cmd}zellij attach -c ${alias}"
         reset_terminal
         if [[ $stay_interactive -eq 1 ]]; then
             return 0
@@ -533,10 +568,10 @@ list_and_connect() {
     trap cleanup EXIT INT TERM HUP
 
     # Cache session status once (avoid SSH call per session per redraw)
-    local ssh_cmd_timeout="${ssh_cmd/ssh/ssh $SSH_QUERY_TIMEOUT}"
+    local ssh_cmd_timeout=("${ssh_cmd[0]}" "${SSH_QUERY_TIMEOUT_OPTS[@]}" "${ssh_cmd[@]:1}")
     local _cached_session_list=""
     refresh_session_cache() {
-        _cached_session_list=$($ssh_cmd_timeout "zellij list-sessions 2>/dev/null" 2>/dev/null | sed 's/\x1b\[[0-9;]*m//g' || echo "")
+        _cached_session_list=$(timeout "$SSH_QUERY_MAX_SECS" "${ssh_cmd_timeout[@]}" "zellij list-sessions 2>/dev/null" 2>/dev/null | sed 's/\x1b\[[0-9;]*m//g' || echo "")
     }
     refresh_session_cache
 
@@ -557,7 +592,9 @@ list_and_connect() {
             local is_exited=false
             [[ "$session" == "[NEW]"* ]] && is_new=true
             # Check cached session list for exited status
-            echo "$_cached_session_list" | grep -q "^${session}.*EXITED" && is_exited=true
+            local safe_session
+            safe_session=$(regex_escape "$session")
+            echo "$_cached_session_list" | grep -Eq "^${safe_session}.*EXITED" && is_exited=true
 
             if [[ $i -eq $selected ]]; then
                 if [[ "$is_new" == "true" ]]; then
@@ -633,10 +670,10 @@ list_and_connect() {
             else
                 local session_name="$selected_session"
                 echo -e "${GREEN}Connecting to session '$session_name'...${NC}"
-                local final_ssh="$ssh_cmd"
-                [[ "$auth_mode" == "auth" ]] && final_ssh="$ssh_cmd_auth"
+                local final_ssh=("${ssh_cmd[@]}")
+                [[ "$auth_mode" == "auth" ]] && final_ssh=("${ssh_cmd_auth[@]}")
                 set_terminal_title "$(build_connection_title "$user" "$host" "$description")"
-                $final_ssh -t "${ZELLIJ_MOUSE_FIX}${cd_cmd}zellij attach ${session_name}"
+                "${final_ssh[@]}" -t "${ZELLIJ_MOUSE_FIX}${cd_cmd}zellij attach ${session_name}"
                 reset_terminal
                 if [[ $stay_interactive -eq 1 ]]; then
                     return 0
@@ -687,8 +724,9 @@ connect_hard_reset() {
     local stay_interactive=0
     [[ "${INTERACTIVE_MODE:-0}" -eq 1 ]] && stay_interactive=1
 
-    # Parse connection
-    local line=$(grep "^${alias}|" "$CONFIG_FILE" 2>/dev/null || echo "")
+    # Parse connection (awk for exact field match — no regex injection)
+    local line
+    line=$(awk -F'|' -v key="$alias" '$1 == key' "$CONFIG_FILE" 2>/dev/null || echo "")
 
     if [[ -z "$line" ]]; then
         echo -e "${RED}Error: Connection '$alias' not found${NC}"
@@ -701,15 +739,22 @@ connect_hard_reset() {
 
     IFS='|' read -r _ host port user directory description key <<< "$line"
 
-    # Build SSH command
-    local ssh_cmd="ssh"
-    if [[ -n "$key" ]]; then
-        ssh_cmd="$ssh_cmd -i $key"
+    # Validate port
+    if ! validate_port "$port" "$alias"; then
+        if [[ $stay_interactive -eq 1 ]]; then
+            return 1
+        else
+            exit 1
+        fi
     fi
-    ssh_cmd="$ssh_cmd $RMATE_FORWARD -p $port ${user}@${host}"
+
+    # Build SSH command array
+    local ssh_cmd=(ssh)
+    [[ -n "$key" ]] && ssh_cmd+=(-i "$key")
+    ssh_cmd+=("${RMATE_FORWARD[@]}" -p "$port" "${user}@${host}")
 
     local cd_cmd=""
-    [[ -n "$directory" ]] && cd_cmd="cd $directory 2>/dev/null; "
+    [[ -n "$directory" ]] && cd_cmd="cd \"${directory}\" 2>/dev/null; "
 
     # If specific session provided (from submenu H), reset only that one
     if [[ -n "$specific_session" ]]; then
@@ -718,7 +763,7 @@ connect_hard_reset() {
         echo ""
         local remote_cmd="zellij delete-session ${specific_session} --force 2>/dev/null; ${cd_cmd}zellij attach -c ${specific_session}"
         set_terminal_title "$(build_connection_title "$user" "$host" "$description")"
-        $ssh_cmd -t "$remote_cmd"
+        "${ssh_cmd[@]}" -t "$remote_cmd"
         reset_terminal
         if [[ $stay_interactive -eq 1 ]]; then
             return 0
@@ -734,9 +779,11 @@ connect_hard_reset() {
     echo ""
 
     # Force-delete primary session and any parallel sessions, then create fresh
-    local remote_cmd="for s in \$(zellij list-sessions 2>/dev/null | sed 's/\x1b\[[0-9;]*m//g' | grep -oE '^${alias}(_[0-9]+)?' || true); do zellij delete-session \"\$s\" --force 2>/dev/null; done; ${cd_cmd}zellij attach -c ${alias}"
+    local safe_alias_remote
+    safe_alias_remote=$(regex_escape "$alias")
+    local remote_cmd="for s in \$(zellij list-sessions 2>/dev/null | sed 's/\x1b\[[0-9;]*m//g' | grep -oE '^${safe_alias_remote}(_[0-9]+)?' || true); do zellij delete-session \"\$s\" --force 2>/dev/null; done; ${cd_cmd}zellij attach -c ${alias}"
     set_terminal_title "$(build_connection_title "$user" "$host" "$description")"
-    $ssh_cmd -t "$remote_cmd"
+    "${ssh_cmd[@]}" -t "$remote_cmd"
     reset_terminal
     if [[ $stay_interactive -eq 1 ]]; then
         return 0
@@ -752,8 +799,9 @@ connect() {
     local stay_interactive=0
     [[ "${INTERACTIVE_MODE:-0}" -eq 1 ]] && stay_interactive=1
 
-    # Parse connection
-    local line=$(grep "^${alias}|" "$CONFIG_FILE" 2>/dev/null || echo "")
+    # Parse connection (awk for exact field match — no regex injection)
+    local line
+    line=$(awk -F'|' -v key="$alias" '$1 == key' "$CONFIG_FILE" 2>/dev/null || echo "")
 
     if [[ -z "$line" ]]; then
         echo -e "${RED}Error: Connection '$alias' not found${NC}"
@@ -766,23 +814,30 @@ connect() {
 
     IFS='|' read -r _ host port user directory description key <<< "$line"
 
-    # Build SSH command (without -t for session queries)
-    local ssh_cmd="ssh"
-    if [[ -n "$key" ]]; then
-        ssh_cmd="$ssh_cmd -i $key"
+    # Validate port
+    if ! validate_port "$port" "$alias"; then
+        if [[ $stay_interactive -eq 1 ]]; then
+            return 1
+        else
+            exit 1
+        fi
     fi
-    ssh_cmd="$ssh_cmd $RMATE_FORWARD -p $port ${user}@${host}"
+
+    # Build SSH command array (without -t for session queries)
+    local ssh_cmd=(ssh)
+    [[ -n "$key" ]] && ssh_cmd+=(-i "$key")
+    ssh_cmd+=("${RMATE_FORWARD[@]}" -p "$port" "${user}@${host}")
 
     local cd_cmd=""
-    [[ -n "$directory" ]] && cd_cmd="cd $directory 2>/dev/null; "
+    [[ -n "$directory" ]] && cd_cmd="cd \"${directory}\" 2>/dev/null; "
 
     # Cleanup dead sessions first
     echo -e "${YELLOW}Checking sessions...${NC}"
-    cleanup_dead_sessions "$alias" "$ssh_cmd"
+    cleanup_dead_sessions "$alias" "${ssh_cmd[@]}"
 
     # Count remaining sessions
     local session_count
-    session_count=$(count_sessions_for_alias "$alias" "$ssh_cmd")
+    session_count=$(count_sessions_for_alias "$alias" "${ssh_cmd[@]}")
 
     if [[ $session_count -gt 1 ]]; then
         # Multiple sessions exist -> go to session submenu
@@ -793,7 +848,7 @@ connect() {
 
     # Get existing session or use primary name
     local sessions
-    sessions=$(get_sessions_for_alias "$alias" "$ssh_cmd")
+    sessions=$(get_sessions_for_alias "$alias" "${ssh_cmd[@]}")
     local session_name
     if [[ $session_count -eq 1 ]]; then
         session_name=$(echo "$sessions" | head -1)
@@ -801,15 +856,13 @@ connect() {
         session_name="$alias"
     fi
 
-    # Build final SSH command with auth port forwarding if needed
-    local final_ssh_cmd="$ssh_cmd"
+    # Build final SSH command array with auth port forwarding if needed
+    local final_ssh_cmd=("${ssh_cmd[@]}")
     if [[ "$auth_mode" == "auth" ]]; then
         # Rebuild with auth port forwarding
-        final_ssh_cmd="ssh"
-        if [[ -n "$key" ]]; then
-            final_ssh_cmd="$final_ssh_cmd -i $key"
-        fi
-        final_ssh_cmd="$final_ssh_cmd -L 1455:localhost:1455 $RMATE_FORWARD -p $port ${user}@${host}"
+        final_ssh_cmd=(ssh)
+        [[ -n "$key" ]] && final_ssh_cmd+=(-i "$key")
+        final_ssh_cmd+=(-L 1455:localhost:1455 "${RMATE_FORWARD[@]}" -p "$port" "${user}@${host}")
     fi
 
     # Build remote command
@@ -830,7 +883,7 @@ connect() {
     set_terminal_title "$(build_connection_title "$user" "$host" "$description")"
 
     # Execute SSH and reset terminal after disconnect
-    run_ssh "$final_ssh_cmd" "$remote_cmd" "$user" "$host" "$port"
+    run_ssh "$remote_cmd" "$user" "$host" "$port" "${final_ssh_cmd[@]}"
     reset_terminal
 }
 
@@ -848,8 +901,9 @@ connect_parallel() {
     local stay_interactive=0
     [[ "${INTERACTIVE_MODE:-0}" -eq 1 ]] && stay_interactive=1
 
-    # Parse connection
-    local line=$(grep "^${alias}|" "$CONFIG_FILE" 2>/dev/null || echo "")
+    # Parse connection (awk for exact field match — no regex injection)
+    local line
+    line=$(awk -F'|' -v key="$alias" '$1 == key' "$CONFIG_FILE" 2>/dev/null || echo "")
 
     if [[ -z "$line" ]]; then
         echo -e "${RED}Error: Connection '$alias' not found${NC}"
@@ -862,23 +916,28 @@ connect_parallel() {
 
     IFS='|' read -r _ host port user directory description key <<< "$line"
 
-    # Build SSH command
-    local ssh_cmd="ssh"
-    if [[ -n "$key" ]]; then
-        ssh_cmd="$ssh_cmd -i $key"
+    # Validate port
+    if ! validate_port "$port" "$alias"; then
+        if [[ $stay_interactive -eq 1 ]]; then
+            return 1
+        else
+            exit 1
+        fi
     fi
-    if [[ "$auth_mode" == "auth" ]]; then
-        ssh_cmd="$ssh_cmd -L 1455:localhost:1455"
-    fi
-    ssh_cmd="$ssh_cmd $RMATE_FORWARD -p $port ${user}@${host}"
+
+    # Build SSH command array
+    local ssh_cmd=(ssh)
+    [[ -n "$key" ]] && ssh_cmd+=(-i "$key")
+    [[ "$auth_mode" == "auth" ]] && ssh_cmd+=(-L 1455:localhost:1455)
+    ssh_cmd+=("${RMATE_FORWARD[@]}" -p "$port" "${user}@${host}")
 
     local cd_cmd=""
-    [[ -n "$directory" ]] && cd_cmd="cd $directory 2>/dev/null; "
+    [[ -n "$directory" ]] && cd_cmd="cd \"${directory}\" 2>/dev/null; "
 
     # Get next available parallel session name
     echo -e "${YELLOW}Finding next available session name...${NC}"
     local session_name
-    session_name=$(get_next_session_name "$alias" "$ssh_cmd")
+    session_name=$(get_next_session_name "$alias" "${ssh_cmd[@]}")
 
     # Build remote command
     local remote_cmd="${ZELLIJ_MOUSE_FIX}${cd_cmd}zellij attach -c ${session_name}"
@@ -898,25 +957,26 @@ connect_parallel() {
     set_terminal_title "$(build_connection_title "$user" "$host" "$description")"
 
     # Execute SSH
-    run_ssh "$ssh_cmd" "$remote_cmd" "$user" "$host" "$port"
+    run_ssh "$remote_cmd" "$user" "$host" "$port" "${ssh_cmd[@]}"
     reset_terminal
 }
 
 # Run SSH with detailed error handling
-# Args: ssh_cmd, remote_cmd, user, host, port
+# Args: remote_cmd, user, host, port, ssh_cmd_elements...
 run_ssh() {
-    local ssh_cmd="$1"
-    local remote_cmd="$2"
-    local user="$3"
-    local host="$4"
-    local port="$5"
+    local remote_cmd="$1"
+    local user="$2"
+    local host="$3"
+    local port="$4"
+    shift 4
+    local ssh_cmd=("$@")
 
     # Run SSH and capture exit code + stderr (using temp file for reliable capture)
     local stderr_file=$(mktemp)
     trap "rm -f '$stderr_file'" RETURN
 
     set +e
-    $ssh_cmd -t "$remote_cmd" 2>"$stderr_file"
+    "${ssh_cmd[@]}" -t "$remote_cmd" 2>"$stderr_file"
     local exit_code=$?
     set -e
 

--- a/sm
+++ b/sm
@@ -433,9 +433,9 @@ interactive_select() {
             connect_parallel "${aliases[$selected]}"
             redraw_menu
         elif [[ "$key" == 'h' || "$key" == 'H' ]]; then
-            # H key - hard reset (always delete and create fresh, no questions)
+            # H key - hard reset (interactive chose deliberately, skip confirm)
             tput cnorm
-            connect_hard_reset "${aliases[$selected]}"
+            connect_hard_reset "${aliases[$selected]}" --force
             redraw_menu
         elif [[ "$key" == 'l' || "$key" == 'L' ]]; then
             # L key - list sessions on server and connect
@@ -759,7 +759,7 @@ list_and_connect() {
             else
                 tput cnorm
                 echo -e "${YELLOW}Hard reset session '$selected_session'...${NC}"
-                connect_hard_reset "$alias" "$selected_session"
+                connect_hard_reset "$alias" "$selected_session" --force
                 exit_or_return 0 "$stay_interactive"; return 0
             fi
         elif [[ "$key" == 'q' || "$key" == 'Q' ]]; then
@@ -771,10 +771,19 @@ list_and_connect() {
 }
 
 # Hard reset - delete session(s) and create fresh
-# If >1 sessions exist, asks user if ALL should be reset
+# Args: alias [specific_session] [--force]
 connect_hard_reset() {
     local alias="$1"
-    local specific_session="${2:-}"  # Optional: reset only this specific session (for submenu H)
+    local specific_session=""
+    local force=false
+    shift
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --force|--yes) force=true ;;
+            *) specific_session="$1" ;;
+        esac
+        shift
+    done
     local stay_interactive=0
     [[ "${INTERACTIVE_MODE:-0}" -eq 1 ]] && stay_interactive=1
 
@@ -808,6 +817,16 @@ connect_hard_reset() {
         "${ssh_cmd[@]}" -t "$remote_cmd"
         reset_terminal
         exit_or_return 0 "$stay_interactive"; return 0
+    fi
+
+    # Confirm unless --force
+    if [[ "$force" != "true" ]]; then
+        echo -e "${YELLOW}This will delete ALL sessions for '$alias' and create a fresh one.${NC}"
+        read -p "Continue? [y/N] " confirm
+        if [[ "$confirm" != "y" && "$confirm" != "Y" ]]; then
+            echo -e "${BLUE}Cancelled.${NC}"
+            exit_or_return 0 "$stay_interactive"; return 0
+        fi
     fi
 
     # Skip session query — just force-delete and create fresh
@@ -1056,6 +1075,105 @@ run_ssh() {
     fi
 }
 
+# Test SSH connectivity for a connection
+test_connection() {
+    local alias="$1"
+
+    if ! parse_connection "$alias"; then
+        echo -e "${RED}Error: Connection '$alias' not found${NC}"
+        exit 1
+    fi
+    local host="$CONN_HOST" port="$CONN_PORT" user="$CONN_USER" key="$CONN_KEY"
+
+    if ! validate_port "$port" "$alias"; then
+        exit 1
+    fi
+
+    echo -e "${YELLOW}Testing connection to $alias (${user}@${host}:${port})...${NC}"
+
+    local ssh_test_cmd=(ssh -o ConnectTimeout=5 -o BatchMode=yes -o StrictHostKeyChecking=accept-new)
+    [[ -n "$key" ]] && ssh_test_cmd+=(-i "$key")
+    ssh_test_cmd+=(-p "$port" "${user}@${host}" "exit 0")
+
+    local start_time=$SECONDS
+    set +e
+    "${ssh_test_cmd[@]}" 2>/dev/null
+    local exit_code=$?
+    set -e
+    local elapsed=$(( SECONDS - start_time ))
+
+    if [[ $exit_code -eq 0 ]]; then
+        echo -e "${GREEN}OK: $alias reachable (${elapsed}s)${NC}"
+    else
+        echo -e "${RED}FAIL: $alias unreachable (exit code $exit_code, ${elapsed}s)${NC}"
+        exit 1
+    fi
+}
+
+# Validate config file
+validate_config() {
+    if [[ ! -f "$CONFIG_FILE" ]]; then
+        echo -e "${RED}Config file not found: $CONFIG_FILE${NC}"
+        exit 1
+    fi
+
+    echo -e "${GREEN}Validating: $CONFIG_FILE${NC}"
+    local errors=0
+    local connections=0
+    local line_num=0
+
+    while IFS= read -r line; do
+        line_num=$((line_num + 1))
+        # Skip comments, empty lines, defaults, host aliases
+        [[ -z "$line" ]] && continue
+        [[ "$line" =~ ^#.*$ ]] && continue
+        [[ "$line" =~ ^default= ]] && continue
+        [[ "$line" =~ ^hostalias: ]] && continue
+
+        connections=$((connections + 1))
+
+        # Parse fields
+        local alias host port user directory description key
+        IFS='|' read -r alias host port user directory description key <<< "$line"
+
+        # Validate required fields
+        if [[ -z "$alias" ]]; then
+            echo -e "${RED}  Line $line_num: missing alias${NC}"
+            errors=$((errors + 1))
+            continue
+        fi
+        if [[ -z "$host" ]]; then
+            echo -e "${RED}  Line $line_num ($alias): missing host${NC}"
+            errors=$((errors + 1))
+        fi
+        if ! validate_port "$port" "$alias" 2>/dev/null; then
+            echo -e "${RED}  Line $line_num ($alias): invalid port '$port'${NC}"
+            errors=$((errors + 1))
+        fi
+        if [[ -z "$user" ]]; then
+            echo -e "${RED}  Line $line_num ($alias): missing user${NC}"
+            errors=$((errors + 1))
+        fi
+
+        # Check SSH key file if specified
+        if [[ -n "$key" ]]; then
+            local expanded_key="${key/#\~/$HOME}"
+            if [[ ! -f "$expanded_key" ]]; then
+                echo -e "${YELLOW}  Line $line_num ($alias): SSH key not found: $key${NC}"
+            fi
+        fi
+    done < "$CONFIG_FILE"
+
+    echo ""
+    echo -e "${BLUE}Connections: $connections${NC}"
+    if [[ $errors -eq 0 ]]; then
+        echo -e "${GREEN}No errors found.${NC}"
+    else
+        echo -e "${RED}Found $errors error(s).${NC}"
+        exit 1
+    fi
+}
+
 # Main
 main() {
     # Pre-parse global flags before init_config (--help, --version, --no-color)
@@ -1122,6 +1240,14 @@ main() {
                 set_default "$2"
             elif [[ "$1" == "edit" ]]; then
                 "${EDITOR:-vi}" "$CONFIG_FILE"
+            elif [[ "$1" == "test" ]]; then
+                if [[ $# -lt 2 ]]; then
+                    echo -e "${RED}Usage: sm test <alias>${NC}"
+                    exit 1
+                fi
+                test_connection "$2"
+            elif [[ "$1" == "validate" || "$1" == "doctor" ]]; then
+                validate_config
             else
                 # Direct connection by alias
                 connect "$1"

--- a/sm
+++ b/sm
@@ -343,6 +343,33 @@ interactive_select() {
     # Set static window title for menu
     set_terminal_title "Secure Shell Manager"
 
+    # Search/filter state
+    local search_mode=false
+    local filter_text=""
+    local filtered_indices=()
+
+    # Rebuild filtered_indices from filter_text
+    rebuild_filter() {
+        filtered_indices=()
+        if [[ -z "$filter_text" ]]; then
+            for i in "${!aliases[@]}"; do
+                filtered_indices+=("$i")
+            done
+        else
+            local lc_filter
+            lc_filter=$(printf '%s' "$filter_text" | tr '[:upper:]' '[:lower:]')
+            for i in "${!aliases[@]}"; do
+                local haystack
+                haystack=$(printf '%s %s %s %s %s' "${aliases[$i]}" "${hostaliases[$i]}" "${users[$i]}" "${directories[$i]}" "${descriptions[$i]}" | tr '[:upper:]' '[:lower:]')
+                if [[ "$haystack" == *"$lc_filter"* ]]; then
+                    filtered_indices+=("$i")
+                fi
+            done
+        fi
+    }
+    # Initialize with all entries
+    rebuild_filter
+
     # Draw function
     draw_menu() {
         # Move to top and clear
@@ -350,32 +377,46 @@ interactive_select() {
         tput ed
 
         echo -e "${GREEN}=== SM - SSH Manager ${SM_VERSION} ===${NC}"
+        if [[ "$search_mode" == "true" || -n "$filter_text" ]]; then
+            echo -e "${BLUE}Filter: ${filter_text}_${NC}"
+        fi
         printf "%-${w_alias}s %-${w_host}s %-${w_user}s %-${w_dir}s %-${w_desc}s\n" "ALIAS" "HOSTALIAS" "USER" "DIRECTORY" "DESCRIPTION"
         printf '%*s\n' "$total" '' | tr ' ' '-'
 
         local wa=$((w_alias - 2))
-        for i in "${!aliases[@]}"; do
-            local is_default=false
-            [[ "${aliases[$i]}" == "$default_conn" ]] && is_default=true
+        local fi_count=${#filtered_indices[@]}
 
-            if [[ $i -eq $selected ]]; then
-                # Selected row - inverse video
-                if [[ "$is_default" == "true" ]]; then
-                    printf "${GREEN}\e[7m> %-${wa}s %-${w_host}s %-${w_user}s %-${w_dir}s %-${w_desc}s\e[27m${NC}\n" "${aliases[$i]}" "${hostaliases[$i]}" "${users[$i]}" "${directories[$i]}" "${descriptions[$i]}"
+        if [[ $fi_count -eq 0 ]]; then
+            echo -e "${YELLOW}  No matches${NC}"
+        else
+            for fi_pos in "${!filtered_indices[@]}"; do
+                local i="${filtered_indices[$fi_pos]}"
+                local is_default=false
+                [[ "${aliases[$i]}" == "$default_conn" ]] && is_default=true
+
+                if [[ $fi_pos -eq $selected ]]; then
+                    # Selected row - inverse video
+                    if [[ "$is_default" == "true" ]]; then
+                        printf "${GREEN}\e[7m> %-${wa}s %-${w_host}s %-${w_user}s %-${w_dir}s %-${w_desc}s\e[27m${NC}\n" "${aliases[$i]}" "${hostaliases[$i]}" "${users[$i]}" "${directories[$i]}" "${descriptions[$i]}"
+                    else
+                        printf "\e[7m> %-${wa}s %-${w_host}s %-${w_user}s %-${w_dir}s %-${w_desc}s\e[27m\n" "${aliases[$i]}" "${hostaliases[$i]}" "${users[$i]}" "${directories[$i]}" "${descriptions[$i]}"
+                    fi
                 else
-                    printf "\e[7m> %-${wa}s %-${w_host}s %-${w_user}s %-${w_dir}s %-${w_desc}s\e[27m\n" "${aliases[$i]}" "${hostaliases[$i]}" "${users[$i]}" "${directories[$i]}" "${descriptions[$i]}"
+                    if [[ "$is_default" == "true" ]]; then
+                        printf "${GREEN}  %-${wa}s %-${w_host}s %-${w_user}s %-${w_dir}s %-${w_desc}s${NC}\n" "${aliases[$i]}" "${hostaliases[$i]}" "${users[$i]}" "${directories[$i]}" "${descriptions[$i]}"
+                    else
+                        printf "  %-${wa}s %-${w_host}s %-${w_user}s %-${w_dir}s %-${w_desc}s\n" "${aliases[$i]}" "${hostaliases[$i]}" "${users[$i]}" "${directories[$i]}" "${descriptions[$i]}"
+                    fi
                 fi
-            else
-                if [[ "$is_default" == "true" ]]; then
-                    printf "${GREEN}  %-${wa}s %-${w_host}s %-${w_user}s %-${w_dir}s %-${w_desc}s${NC}\n" "${aliases[$i]}" "${hostaliases[$i]}" "${users[$i]}" "${directories[$i]}" "${descriptions[$i]}"
-                else
-                    printf "  %-${wa}s %-${w_host}s %-${w_user}s %-${w_dir}s %-${w_desc}s\n" "${aliases[$i]}" "${hostaliases[$i]}" "${users[$i]}" "${directories[$i]}" "${descriptions[$i]}"
-                fi
-            fi
-        done
+            done
+        fi
 
         echo ""
-        echo -e "${YELLOW}↑↓ Navigate | Enter: Connect | A: Auth | P: Parallel | L: List | H: Hard Reset | D: Default | Q: Exit${NC}"
+        if [[ "$search_mode" == "true" ]]; then
+            echo -e "${YELLOW}Type to filter | Backspace: delete | Esc: clear filter | Enter: select${NC}"
+        else
+            echo -e "${YELLOW}↑↓ Navigate | Enter: Connect | /: Search | A: Auth | P: Parallel | L: List | H: Hard Reset | D: Default | Q: Exit${NC}"
+        fi
     }
 
     redraw_menu() {
@@ -385,31 +426,112 @@ interactive_select() {
         draw_menu
     }
 
+    # Helper: get the real index of the selected item in the filtered list
+    get_selected_real_index() {
+        local fi_count=${#filtered_indices[@]}
+        if [[ $fi_count -eq 0 ]]; then
+            echo -1
+            return
+        fi
+        echo "${filtered_indices[$selected]}"
+    }
+
     # Draw menu
     redraw_menu
 
     # Read keys
     while true; do
+        local fi_count=${#filtered_indices[@]}
         # Read single key
         IFS= read -rsn1 key || continue
 
+        if [[ "$search_mode" == "true" ]]; then
+            # Search mode key handling
+            if [[ "$key" == $'\x1b' ]]; then
+                read -rsn2 -t 0.1 seq || true
+                if [[ "$seq" == '[A' ]]; then
+                    # Up arrow in search mode
+                    if [[ $fi_count -gt 0 ]]; then
+                        if [[ $selected -gt 0 ]]; then
+                            selected=$((selected - 1))
+                        else
+                            selected=$((fi_count - 1))
+                        fi
+                    fi
+                    draw_menu
+                elif [[ "$seq" == '[B' ]]; then
+                    # Down arrow in search mode
+                    if [[ $fi_count -gt 0 ]]; then
+                        if [[ $selected -lt $((fi_count - 1)) ]]; then
+                            selected=$((selected + 1))
+                        else
+                            selected=0
+                        fi
+                    fi
+                    draw_menu
+                elif [[ -z "$seq" ]]; then
+                    # Escape - exit search mode, clear filter
+                    search_mode=false
+                    filter_text=""
+                    rebuild_filter
+                    selected=0
+                    draw_menu
+                fi
+            elif [[ "$key" == '' ]]; then
+                # Enter - select current and exit search mode
+                search_mode=false
+                if [[ $fi_count -gt 0 ]]; then
+                    local real_idx
+                    real_idx=$(get_selected_real_index)
+                    tput cnorm
+                    connect "${aliases[$real_idx]}"
+                    rebuild_filter
+                    selected=0
+                    redraw_menu
+                fi
+            elif [[ "$key" == $'\x7f' || "$key" == $'\x08' ]]; then
+                # Backspace - remove last char
+                if [[ ${#filter_text} -gt 0 ]]; then
+                    filter_text="${filter_text%?}"
+                    rebuild_filter
+                    selected=0
+                fi
+                if [[ -z "$filter_text" ]]; then
+                    search_mode=false
+                fi
+                draw_menu
+            elif [[ "$key" =~ ^[[:print:]]$ ]]; then
+                # Printable character - add to filter
+                filter_text="${filter_text}${key}"
+                rebuild_filter
+                selected=0
+                draw_menu
+            fi
+            continue
+        fi
+
+        # Normal mode key handling
         if [[ "$key" == $'\x1b' ]]; then
             # Escape sequence - read more
             read -rsn2 -t 0.1 seq || true
             if [[ "$seq" == '[A' ]]; then
                 # Up arrow - wrap to bottom
-                if [[ $selected -gt 0 ]]; then
-                    selected=$((selected - 1))
-                else
-                    selected=$((count - 1))
+                if [[ $fi_count -gt 0 ]]; then
+                    if [[ $selected -gt 0 ]]; then
+                        selected=$((selected - 1))
+                    else
+                        selected=$((fi_count - 1))
+                    fi
                 fi
                 draw_menu
             elif [[ "$seq" == '[B' ]]; then
                 # Down arrow - wrap to top
-                if [[ $selected -lt $((count - 1)) ]]; then
-                    selected=$((selected + 1))
-                else
-                    selected=0
+                if [[ $fi_count -gt 0 ]]; then
+                    if [[ $selected -lt $((fi_count - 1)) ]]; then
+                        selected=$((selected + 1))
+                    else
+                        selected=0
+                    fi
                 fi
                 draw_menu
             elif [[ -z "$seq" ]]; then
@@ -417,36 +539,77 @@ interactive_select() {
                 tput cnorm
                 exit 0
             fi
+        elif [[ "$key" == '/' ]]; then
+            # Enter search mode
+            search_mode=true
+            filter_text=""
+            rebuild_filter
+            selected=0
+            draw_menu
         elif [[ "$key" == '' ]]; then
             # Enter key - connect with zellij session restore
-            tput cnorm
-            connect "${aliases[$selected]}"
-            redraw_menu
+            if [[ $fi_count -gt 0 ]]; then
+                local real_idx
+                real_idx=$(get_selected_real_index)
+                tput cnorm
+                connect "${aliases[$real_idx]}"
+                filter_text=""
+                rebuild_filter
+                selected=0
+                redraw_menu
+            fi
         elif [[ "$key" == 'a' || "$key" == 'A' ]]; then
-            # A key - Auth mode with port forwarding (1455)
-            tput cnorm
-            connect_auth "${aliases[$selected]}"
-            redraw_menu
+            if [[ $fi_count -gt 0 ]]; then
+                local real_idx
+                real_idx=$(get_selected_real_index)
+                tput cnorm
+                connect_auth "${aliases[$real_idx]}"
+                filter_text=""
+                rebuild_filter
+                selected=0
+                redraw_menu
+            fi
         elif [[ "$key" == 'p' || "$key" == 'P' ]]; then
-            # P key - create new parallel session
-            tput cnorm
-            connect_parallel "${aliases[$selected]}"
-            redraw_menu
+            if [[ $fi_count -gt 0 ]]; then
+                local real_idx
+                real_idx=$(get_selected_real_index)
+                tput cnorm
+                connect_parallel "${aliases[$real_idx]}"
+                filter_text=""
+                rebuild_filter
+                selected=0
+                redraw_menu
+            fi
         elif [[ "$key" == 'h' || "$key" == 'H' ]]; then
-            # H key - hard reset (interactive chose deliberately, skip confirm)
-            tput cnorm
-            connect_hard_reset "${aliases[$selected]}" --force
-            redraw_menu
+            if [[ $fi_count -gt 0 ]]; then
+                local real_idx
+                real_idx=$(get_selected_real_index)
+                tput cnorm
+                connect_hard_reset "${aliases[$real_idx]}" --force
+                filter_text=""
+                rebuild_filter
+                selected=0
+                redraw_menu
+            fi
         elif [[ "$key" == 'l' || "$key" == 'L' ]]; then
-            # L key - list sessions on server and connect
-            tput cnorm
-            list_and_connect "${aliases[$selected]}"
-            redraw_menu
+            if [[ $fi_count -gt 0 ]]; then
+                local real_idx
+                real_idx=$(get_selected_real_index)
+                tput cnorm
+                list_and_connect "${aliases[$real_idx]}"
+                filter_text=""
+                rebuild_filter
+                selected=0
+                redraw_menu
+            fi
         elif [[ "$key" == 'd' || "$key" == 'D' ]]; then
-            # D key - set default
-            set_default "${aliases[$selected]}"
-            default_conn="${aliases[$selected]}"
-            draw_menu
+            if [[ $fi_count -gt 0 ]]; then
+                local real_idx
+                real_idx=$(get_selected_real_index)
+                set_default "${aliases[$real_idx]}"
+                default_conn="${aliases[$real_idx]}"
+                draw_menu
+            fi
         elif [[ "$key" == 'q' || "$key" == 'Q' ]]; then
             # Q to quit
             tput cnorm
@@ -1248,6 +1411,32 @@ main() {
                 test_connection "$2"
             elif [[ "$1" == "validate" || "$1" == "doctor" ]]; then
                 validate_config
+            elif [[ "$1" == "auth" ]]; then
+                if [[ $# -lt 2 ]]; then
+                    echo -e "${RED}Usage: sm auth <alias>${NC}"
+                    exit 1
+                fi
+                connect_auth "$2"
+            elif [[ "$1" == "parallel" ]]; then
+                if [[ $# -lt 2 ]]; then
+                    echo -e "${RED}Usage: sm parallel <alias>${NC}"
+                    exit 1
+                fi
+                connect_parallel "$2"
+            elif [[ "$1" == "reset" ]]; then
+                if [[ $# -lt 2 ]]; then
+                    echo -e "${RED}Usage: sm reset <alias> [--force]${NC}"
+                    exit 1
+                fi
+                local reset_alias="$2"
+                shift 2
+                connect_hard_reset "$reset_alias" "$@"
+            elif [[ "$1" == "sessions" ]]; then
+                if [[ $# -lt 2 ]]; then
+                    echo -e "${RED}Usage: sm sessions <alias>${NC}"
+                    exit 1
+                fi
+                list_and_connect "$2"
             else
                 # Direct connection by alias
                 connect "$1"

--- a/sm
+++ b/sm
@@ -476,7 +476,7 @@ interactive_select() {
             # Search mode key handling
             if [[ "$key" == $'\x1b' ]]; then
                 read -rsn2 -t 0.1 seq || true
-                if [[ "$seq" == '[A' ]]; then
+                if [[ "$seq" == '[A' || "$seq" == 'OA' ]]; then
                     # Up arrow in search mode
                     if [[ $fi_count -gt 0 ]]; then
                         if [[ $selected -gt 0 ]]; then
@@ -486,7 +486,7 @@ interactive_select() {
                         fi
                     fi
                     draw_menu
-                elif [[ "$seq" == '[B' ]]; then
+                elif [[ "$seq" == '[B' || "$seq" == 'OB' ]]; then
                     # Down arrow in search mode
                     if [[ $fi_count -gt 0 ]]; then
                         if [[ $selected -lt $((fi_count - 1)) ]]; then
@@ -541,7 +541,7 @@ interactive_select() {
         if [[ "$key" == $'\x1b' ]]; then
             # Escape sequence - read more
             read -rsn2 -t 0.1 seq || true
-            if [[ "$seq" == '[A' ]]; then
+            if [[ "$seq" == '[A' || "$seq" == 'OA' ]]; then
                 # Up arrow - wrap to bottom
                 if [[ $fi_count -gt 0 ]]; then
                     if [[ $selected -gt 0 ]]; then
@@ -551,7 +551,7 @@ interactive_select() {
                     fi
                 fi
                 draw_menu
-            elif [[ "$seq" == '[B' ]]; then
+            elif [[ "$seq" == '[B' || "$seq" == 'OB' ]]; then
                 # Down arrow - wrap to top
                 if [[ $fi_count -gt 0 ]]; then
                     if [[ $selected -lt $((fi_count - 1)) ]]; then
@@ -897,7 +897,7 @@ list_and_connect() {
 
         if [[ "$key" == $'\x1b' ]]; then
             read -rsn2 -t 0.1 seq || true
-            if [[ "$seq" == '[A' ]]; then
+            if [[ "$seq" == '[A' || "$seq" == 'OA' ]]; then
                 # Up arrow
                 if [[ $selected -gt 0 ]]; then
                     selected=$((selected - 1))
@@ -905,7 +905,7 @@ list_and_connect() {
                     selected=$((count - 1))
                 fi
                 draw_sessions
-            elif [[ "$seq" == '[B' ]]; then
+            elif [[ "$seq" == '[B' || "$seq" == 'OB' ]]; then
                 # Down arrow
                 if [[ $selected -lt $((count - 1)) ]]; then
                     selected=$((selected + 1))

--- a/sm
+++ b/sm
@@ -63,6 +63,67 @@ reset_terminal() {
     stty sane 2>/dev/null
 }
 
+# === DRY Helper Functions ===
+
+# Parse connection config by alias, sets CONN_* globals
+parse_connection() {
+    local alias="$1"
+    CONN_HOST="" CONN_PORT="" CONN_USER="" CONN_DIR="" CONN_DESC="" CONN_KEY=""
+    local line
+    line=$(awk -F'|' -v key="$alias" '$1 == key' "$CONFIG_FILE" 2>/dev/null || echo "")
+    [[ -z "$line" ]] && return 1
+    IFS='|' read -r _ CONN_HOST CONN_PORT CONN_USER CONN_DIR CONN_DESC CONN_KEY <<< "$line"
+    return 0
+}
+
+# Exit or return based on interactive mode
+exit_or_return() {
+    local code="${1:-0}"
+    local stay="${2:-0}"
+    if [[ $stay -eq 1 ]]; then
+        return "$code"
+    else
+        exit "$code"
+    fi
+}
+
+# Build SSH command array, sets global SSH_CMD
+build_ssh_cmd() {
+    local host="$1" port="$2" user="$3" key="$4" auth_mode="${5:-}"
+    SSH_CMD=()
+    SSH_CMD=(ssh)
+    [[ -n "$key" ]] && SSH_CMD+=(-i "$key")
+    [[ "$auth_mode" == "auth" ]] && SSH_CMD+=(-L 1455:localhost:1455)
+    SSH_CMD+=("${RMATE_FORWARD[@]}" -p "$port" "${user}@${host}")
+}
+
+# Build cd command string for remote execution
+build_cd_cmd() {
+    local directory="$1"
+    [[ -n "$directory" ]] && echo "cd \"${directory}\" 2>/dev/null; " || echo ""
+}
+
+# Calculate column widths for connection display, sets W_* globals
+calculate_column_widths() {
+    W_ALIAS=5; W_HOST=9; W_USER=4; W_DIR=9
+    while IFS='|' read -r alias host port user directory description key; do
+        [[ "$alias" =~ ^#.*$ ]] && continue
+        [[ -z "$alias" ]] && continue
+        [[ "$alias" =~ ^default= ]] && continue
+        [[ "$alias" =~ ^hostalias: ]] && continue
+        local ha=$(get_host_alias "$host")
+        (( ${#alias} > W_ALIAS )) && W_ALIAS=${#alias}
+        (( ${#ha} > W_HOST )) && W_HOST=${#ha}
+        (( ${#user} > W_USER )) && W_USER=${#user}
+        (( ${#directory} > W_DIR )) && W_DIR=${#directory}
+    done < "$CONFIG_FILE"
+    W_ALIAS=$((W_ALIAS + 2))
+    W_HOST=$((W_HOST + 2))
+    W_USER=$((W_USER + 2))
+}
+
+# === End DRY Helper Functions ===
+
 # Zellij mouse configuration
 # - Pane selection with mouse requires mouse_mode true (zellij default)
 # - Shift+RightClick paste depends on terminal emulator (Windows Terminal: use Ctrl+Shift+V)
@@ -139,21 +200,8 @@ list_connections() {
     local default_conn=$(get_default)
 
     # First pass: calculate column widths
-    local w_alias=5 w_host=9 w_user=4 w_dir=9
-    while IFS='|' read -r alias host port user directory description key; do
-        [[ "$alias" =~ ^#.*$ ]] && continue
-        [[ -z "$alias" ]] && continue
-        [[ "$alias" =~ ^default= ]] && continue
-        [[ "$alias" =~ ^hostalias: ]] && continue
-        local ha=$(get_host_alias "$host")
-        (( ${#alias} > w_alias )) && w_alias=${#alias}
-        (( ${#ha} > w_host )) && w_host=${#ha}
-        (( ${#user} > w_user )) && w_user=${#user}
-        (( ${#directory} > w_dir )) && w_dir=${#directory}
-    done < "$CONFIG_FILE"
-    w_alias=$((w_alias + 2))
-    w_host=$((w_host + 2))
-    w_user=$((w_user + 2))
+    calculate_column_widths
+    local w_alias=$W_ALIAS w_host=$W_HOST w_user=$W_USER w_dir=$W_DIR
 
     local total=$((w_alias + w_host + w_user + w_dir))
 
@@ -208,16 +256,8 @@ interactive_select() {
     fi
 
     # Calculate dynamic column widths
-    local w_alias=5 w_host=9 w_user=4 w_dir=9
-    for i in "${!aliases[@]}"; do
-        (( ${#aliases[$i]} > w_alias )) && w_alias=${#aliases[$i]}
-        (( ${#hostaliases[$i]} > w_host )) && w_host=${#hostaliases[$i]}
-        (( ${#users[$i]} > w_user )) && w_user=${#users[$i]}
-        (( ${#directories[$i]} > w_dir )) && w_dir=${#directories[$i]}
-    done
-    w_alias=$((w_alias + 2))
-    w_host=$((w_host + 2))
-    w_user=$((w_user + 2))
+    calculate_column_widths
+    local w_alias=$W_ALIAS w_host=$W_HOST w_user=$W_USER w_dir=$W_DIR
     local total=$((w_alias + w_host + w_user + w_dir + 2))
 
     # Find initial selection (default or first)
@@ -476,42 +516,29 @@ list_and_connect() {
     local stay_interactive=0
     [[ "${INTERACTIVE_MODE:-0}" -eq 1 ]] && stay_interactive=1
 
-    # Parse connection (awk for exact field match — no regex injection)
-    local line
-    line=$(awk -F'|' -v key="$alias" '$1 == key' "$CONFIG_FILE" 2>/dev/null || echo "")
-
-    if [[ -z "$line" ]]; then
+    # Parse connection
+    if ! parse_connection "$alias"; then
         echo -e "${RED}Error: Connection '$alias' not found${NC}"
-        if [[ $stay_interactive -eq 1 ]]; then
-            return 1
-        else
-            exit 1
-        fi
+        exit_or_return 1 "$stay_interactive"
+        return 1
     fi
-
-    IFS='|' read -r _ host port user directory description key <<< "$line"
+    local host="$CONN_HOST" port="$CONN_PORT" user="$CONN_USER"
+    local directory="$CONN_DIR" description="$CONN_DESC" key="$CONN_KEY"
 
     # Validate port
     if ! validate_port "$port" "$alias"; then
-        if [[ $stay_interactive -eq 1 ]]; then
-            return 1
-        else
-            exit 1
-        fi
+        exit_or_return 1 "$stay_interactive"
+        return 1
     fi
 
-    # Build SSH command array (base without auth port)
-    local ssh_cmd=(ssh)
-    [[ -n "$key" ]] && ssh_cmd+=(-i "$key")
-    ssh_cmd+=("${RMATE_FORWARD[@]}" -p "$port" "${user}@${host}")
+    # Build SSH command arrays (base and auth)
+    build_ssh_cmd "$host" "$port" "$user" "$key"
+    local ssh_cmd=("${SSH_CMD[@]}")
+    build_ssh_cmd "$host" "$port" "$user" "$key" "auth"
+    local ssh_cmd_auth=("${SSH_CMD[@]}")
 
-    # Build SSH command array with auth port if needed
-    local ssh_cmd_auth=(ssh)
-    [[ -n "$key" ]] && ssh_cmd_auth+=(-i "$key")
-    ssh_cmd_auth+=(-L 1455:localhost:1455 "${RMATE_FORWARD[@]}" -p "$port" "${user}@${host}")
-
-    local cd_cmd=""
-    [[ -n "$directory" ]] && cd_cmd="cd \"${directory}\" 2>/dev/null; "
+    local cd_cmd
+    cd_cmd=$(build_cd_cmd "$directory")
 
     echo -e "${GREEN}=== Sessions on $alias ($description) ===${NC}"
     echo -e "${YELLOW}Fetching sessions...${NC}"
@@ -524,28 +551,16 @@ list_and_connect() {
         echo -e "${RED}No sessions found for '$alias'.${NC}"
         read -p "Create new session '$alias'? [Y/n/b=back] " confirm
         if [[ "$confirm" == "n" || "$confirm" == "N" ]]; then
-            if [[ $stay_interactive -eq 1 ]]; then
-                return 0
-            else
-                exit 0
-            fi
+            exit_or_return 0 "$stay_interactive"; return 0
         elif [[ "$confirm" == "b" || "$confirm" == "B" ]]; then
-            if [[ $stay_interactive -eq 1 ]]; then
-                return 0
-            else
-                exit 0
-            fi
+            exit_or_return 0 "$stay_interactive"; return 0
         fi
         local final_ssh=("${ssh_cmd[@]}")
         [[ "$auth_mode" == "auth" ]] && final_ssh=("${ssh_cmd_auth[@]}")
         set_terminal_title "$(build_connection_title "$user" "$host" "$description")"
         "${final_ssh[@]}" -t "${ZELLIJ_MOUSE_FIX}${cd_cmd}zellij attach -c ${alias}"
         reset_terminal
-        if [[ $stay_interactive -eq 1 ]]; then
-            return 0
-        else
-            exit 0
-        fi
+        exit_or_return 0 "$stay_interactive"; return 0
     fi
 
     # Build session array from filtered sessions
@@ -648,11 +663,7 @@ list_and_connect() {
             elif [[ -z "$seq" ]]; then
                 # Escape - back
                 tput cnorm
-                if [[ $stay_interactive -eq 1 ]]; then
-                    return 0
-                else
-                    exit 0
-                fi
+                exit_or_return 0 "$stay_interactive"; return 0
             fi
         elif [[ "$key" == '' ]]; then
             # Enter - connect to selected or create new parallel
@@ -662,11 +673,7 @@ list_and_connect() {
             if [[ "$selected_session" == "[NEW]"* ]]; then
                 echo -e "${GREEN}Creating new parallel session...${NC}"
                 connect_parallel "$alias" "$auth_mode"
-                if [[ $stay_interactive -eq 1 ]]; then
-                    return 0
-                else
-                    exit 0
-                fi
+                exit_or_return 0 "$stay_interactive"; return 0
             else
                 local session_name="$selected_session"
                 echo -e "${GREEN}Connecting to session '$session_name'...${NC}"
@@ -675,11 +682,7 @@ list_and_connect() {
                 set_terminal_title "$(build_connection_title "$user" "$host" "$description")"
                 "${final_ssh[@]}" -t "${ZELLIJ_MOUSE_FIX}${cd_cmd}zellij attach ${session_name}"
                 reset_terminal
-                if [[ $stay_interactive -eq 1 ]]; then
-                    return 0
-                else
-                    exit 0
-                fi
+                exit_or_return 0 "$stay_interactive"; return 0
             fi
         elif [[ "$key" == 'h' || "$key" == 'H' ]]; then
             # H - hard reset selected session only
@@ -689,29 +692,17 @@ list_and_connect() {
                 tput cnorm
                 echo -e "${GREEN}Creating new parallel session...${NC}"
                 connect_parallel "$alias" "$auth_mode"
-                if [[ $stay_interactive -eq 1 ]]; then
-                    return 0
-                else
-                    exit 0
-                fi
+                exit_or_return 0 "$stay_interactive"; return 0
             else
                 tput cnorm
                 echo -e "${YELLOW}Hard reset session '$selected_session'...${NC}"
                 connect_hard_reset "$alias" "$selected_session"
-                if [[ $stay_interactive -eq 1 ]]; then
-                    return 0
-                else
-                    exit 0
-                fi
+                exit_or_return 0 "$stay_interactive"; return 0
             fi
         elif [[ "$key" == 'q' || "$key" == 'Q' ]]; then
             # Q - back to main menu
             tput cnorm
-            if [[ $stay_interactive -eq 1 ]]; then
-                return 0
-            else
-                exit 0
-            fi
+            exit_or_return 0 "$stay_interactive"; return 0
         fi
     done
 }
@@ -724,37 +715,25 @@ connect_hard_reset() {
     local stay_interactive=0
     [[ "${INTERACTIVE_MODE:-0}" -eq 1 ]] && stay_interactive=1
 
-    # Parse connection (awk for exact field match — no regex injection)
-    local line
-    line=$(awk -F'|' -v key="$alias" '$1 == key' "$CONFIG_FILE" 2>/dev/null || echo "")
-
-    if [[ -z "$line" ]]; then
+    # Parse connection
+    if ! parse_connection "$alias"; then
         echo -e "${RED}Error: Connection '$alias' not found${NC}"
-        if [[ $stay_interactive -eq 1 ]]; then
-            return 1
-        else
-            exit 1
-        fi
+        exit_or_return 1 "$stay_interactive"; return 1
     fi
-
-    IFS='|' read -r _ host port user directory description key <<< "$line"
+    local host="$CONN_HOST" port="$CONN_PORT" user="$CONN_USER"
+    local directory="$CONN_DIR" description="$CONN_DESC" key="$CONN_KEY"
 
     # Validate port
     if ! validate_port "$port" "$alias"; then
-        if [[ $stay_interactive -eq 1 ]]; then
-            return 1
-        else
-            exit 1
-        fi
+        exit_or_return 1 "$stay_interactive"; return 1
     fi
 
     # Build SSH command array
-    local ssh_cmd=(ssh)
-    [[ -n "$key" ]] && ssh_cmd+=(-i "$key")
-    ssh_cmd+=("${RMATE_FORWARD[@]}" -p "$port" "${user}@${host}")
+    build_ssh_cmd "$host" "$port" "$user" "$key"
+    local ssh_cmd=("${SSH_CMD[@]}")
 
-    local cd_cmd=""
-    [[ -n "$directory" ]] && cd_cmd="cd \"${directory}\" 2>/dev/null; "
+    local cd_cmd
+    cd_cmd=$(build_cd_cmd "$directory")
 
     # If specific session provided (from submenu H), reset only that one
     if [[ -n "$specific_session" ]]; then
@@ -765,11 +744,7 @@ connect_hard_reset() {
         set_terminal_title "$(build_connection_title "$user" "$host" "$description")"
         "${ssh_cmd[@]}" -t "$remote_cmd"
         reset_terminal
-        if [[ $stay_interactive -eq 1 ]]; then
-            return 0
-        else
-            exit 0
-        fi
+        exit_or_return 0 "$stay_interactive"; return 0
     fi
 
     # Skip session query — just force-delete and create fresh
@@ -785,11 +760,7 @@ connect_hard_reset() {
     set_terminal_title "$(build_connection_title "$user" "$host" "$description")"
     "${ssh_cmd[@]}" -t "$remote_cmd"
     reset_terminal
-    if [[ $stay_interactive -eq 1 ]]; then
-        return 0
-    else
-        exit 0
-    fi
+    exit_or_return 0 "$stay_interactive"; return 0
 }
 
 # Connect to a connection (smart routing based on session count)
@@ -799,37 +770,25 @@ connect() {
     local stay_interactive=0
     [[ "${INTERACTIVE_MODE:-0}" -eq 1 ]] && stay_interactive=1
 
-    # Parse connection (awk for exact field match — no regex injection)
-    local line
-    line=$(awk -F'|' -v key="$alias" '$1 == key' "$CONFIG_FILE" 2>/dev/null || echo "")
-
-    if [[ -z "$line" ]]; then
+    # Parse connection
+    if ! parse_connection "$alias"; then
         echo -e "${RED}Error: Connection '$alias' not found${NC}"
-        if [[ $stay_interactive -eq 1 ]]; then
-            return 1
-        else
-            exit 1
-        fi
+        exit_or_return 1 "$stay_interactive"; return 1
     fi
-
-    IFS='|' read -r _ host port user directory description key <<< "$line"
+    local host="$CONN_HOST" port="$CONN_PORT" user="$CONN_USER"
+    local directory="$CONN_DIR" description="$CONN_DESC" key="$CONN_KEY"
 
     # Validate port
     if ! validate_port "$port" "$alias"; then
-        if [[ $stay_interactive -eq 1 ]]; then
-            return 1
-        else
-            exit 1
-        fi
+        exit_or_return 1 "$stay_interactive"; return 1
     fi
 
-    # Build SSH command array (without -t for session queries)
-    local ssh_cmd=(ssh)
-    [[ -n "$key" ]] && ssh_cmd+=(-i "$key")
-    ssh_cmd+=("${RMATE_FORWARD[@]}" -p "$port" "${user}@${host}")
+    # Build SSH command array
+    build_ssh_cmd "$host" "$port" "$user" "$key"
+    local ssh_cmd=("${SSH_CMD[@]}")
 
-    local cd_cmd=""
-    [[ -n "$directory" ]] && cd_cmd="cd \"${directory}\" 2>/dev/null; "
+    local cd_cmd
+    cd_cmd=$(build_cd_cmd "$directory")
 
     # Cleanup dead sessions first
     echo -e "${YELLOW}Checking sessions...${NC}"
@@ -859,10 +818,8 @@ connect() {
     # Build final SSH command array with auth port forwarding if needed
     local final_ssh_cmd=("${ssh_cmd[@]}")
     if [[ "$auth_mode" == "auth" ]]; then
-        # Rebuild with auth port forwarding
-        final_ssh_cmd=(ssh)
-        [[ -n "$key" ]] && final_ssh_cmd+=(-i "$key")
-        final_ssh_cmd+=(-L 1455:localhost:1455 "${RMATE_FORWARD[@]}" -p "$port" "${user}@${host}")
+        build_ssh_cmd "$host" "$port" "$user" "$key" "auth"
+        final_ssh_cmd=("${SSH_CMD[@]}")
     fi
 
     # Build remote command
@@ -901,38 +858,25 @@ connect_parallel() {
     local stay_interactive=0
     [[ "${INTERACTIVE_MODE:-0}" -eq 1 ]] && stay_interactive=1
 
-    # Parse connection (awk for exact field match — no regex injection)
-    local line
-    line=$(awk -F'|' -v key="$alias" '$1 == key' "$CONFIG_FILE" 2>/dev/null || echo "")
-
-    if [[ -z "$line" ]]; then
+    # Parse connection
+    if ! parse_connection "$alias"; then
         echo -e "${RED}Error: Connection '$alias' not found${NC}"
-        if [[ $stay_interactive -eq 1 ]]; then
-            return 1
-        else
-            exit 1
-        fi
+        exit_or_return 1 "$stay_interactive"; return 1
     fi
-
-    IFS='|' read -r _ host port user directory description key <<< "$line"
+    local host="$CONN_HOST" port="$CONN_PORT" user="$CONN_USER"
+    local directory="$CONN_DIR" description="$CONN_DESC" key="$CONN_KEY"
 
     # Validate port
     if ! validate_port "$port" "$alias"; then
-        if [[ $stay_interactive -eq 1 ]]; then
-            return 1
-        else
-            exit 1
-        fi
+        exit_or_return 1 "$stay_interactive"; return 1
     fi
 
     # Build SSH command array
-    local ssh_cmd=(ssh)
-    [[ -n "$key" ]] && ssh_cmd+=(-i "$key")
-    [[ "$auth_mode" == "auth" ]] && ssh_cmd+=(-L 1455:localhost:1455)
-    ssh_cmd+=("${RMATE_FORWARD[@]}" -p "$port" "${user}@${host}")
+    build_ssh_cmd "$host" "$port" "$user" "$key" "$auth_mode"
+    local ssh_cmd=("${SSH_CMD[@]}")
 
-    local cd_cmd=""
-    [[ -n "$directory" ]] && cd_cmd="cd \"${directory}\" 2>/dev/null; "
+    local cd_cmd
+    cd_cmd=$(build_cd_cmd "$directory")
 
     # Get next available parallel session name
     echo -e "${YELLOW}Finding next available session name...${NC}"

--- a/sm
+++ b/sm
@@ -24,12 +24,68 @@ CONFIG_DIR="${HOME}/.config/sm"
 CONFIG_FILE="${CONFIG_DIR}/connections.conf"
 INTERACTIVE_MODE=0
 
-# Colors
+# Colors (may be cleared by --no-color or NO_COLOR env var)
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 BLUE='\033[0;34m'
 NC='\033[0m' # No Color
+
+# Disable colors if NO_COLOR env var is set (https://no-color.org/)
+if [[ -n "${NO_COLOR:-}" ]]; then
+    RED='' GREEN='' YELLOW='' BLUE='' NC=''
+fi
+
+# Timeout wrapper: falls back to running command directly if timeout is unavailable
+HAS_TIMEOUT=true
+if ! command -v timeout &>/dev/null; then
+    HAS_TIMEOUT=false
+fi
+_timeout() {
+    if [[ "$HAS_TIMEOUT" == "true" ]]; then
+        timeout "$@"
+    else
+        # Skip the timeout duration arg, run command directly
+        shift
+        "$@"
+    fi
+}
+
+# Show usage information
+show_help() {
+    cat <<'HELPEOF'
+SM - SSH Manager
+Quick SSH connection manager with zellij session persistence.
+
+Usage:
+  sm                          Interactive connection selector
+  sm <alias>                  Connect to alias directly
+  sm list                     List all connections
+  sm set <alias>              Set default connection
+  sm edit                     Open config in $EDITOR
+  sm test <alias>             Test SSH connectivity
+  sm validate                 Validate config file
+  sm add                      Add a new connection (wizard)
+  sm remove <alias>           Remove a connection
+  sm auth <alias>             Connect with auth port forwarding (1455)
+  sm parallel <alias>         Create a new parallel session
+  sm reset <alias> [--force]  Hard reset sessions for alias
+  sm sessions <alias>         List and select sessions on server
+  sm completions [bash|zsh]   Output shell completion script
+  sm --help, -h               Show this help
+  sm --version, -v            Show version
+
+Shortcuts:
+  smd                         Connect to default connection
+  sml                         List sessions on default server
+
+Config: ~/.config/sm/connections.conf
+Format: alias|host|port|user|directory|description|[ssh_key]
+
+Options:
+  --no-color                  Disable colored output
+HELPEOF
+}
 
 # Escape string for use in regex patterns (grep -E, bash [[ =~ ]])
 regex_escape() {
@@ -37,8 +93,11 @@ regex_escape() {
 }
 
 # Set terminal window title (user@hostalias - description)
+# Strips control characters to prevent terminal escape injection
 set_terminal_title() {
-    printf '\033]0;%s\007' "$1"
+    local sanitized
+    sanitized=$(printf '%s' "$1" | tr -d '\000-\037\177')
+    printf '\033]0;%s\007' "$sanitized"
 }
 
 # Build a descriptive terminal title from connection info
@@ -105,7 +164,7 @@ build_cd_cmd() {
 
 # Calculate column widths for connection display, sets W_* globals
 calculate_column_widths() {
-    W_ALIAS=5; W_HOST=9; W_USER=4; W_DIR=9
+    W_ALIAS=5; W_HOST=9; W_USER=4; W_DIR=9; W_DESC=11
     while IFS='|' read -r alias host port user directory description key; do
         [[ "$alias" =~ ^#.*$ ]] && continue
         [[ -z "$alias" ]] && continue
@@ -116,10 +175,12 @@ calculate_column_widths() {
         (( ${#ha} > W_HOST )) && W_HOST=${#ha}
         (( ${#user} > W_USER )) && W_USER=${#user}
         (( ${#directory} > W_DIR )) && W_DIR=${#directory}
+        (( ${#description} > W_DESC )) && W_DESC=${#description}
     done < "$CONFIG_FILE"
     W_ALIAS=$((W_ALIAS + 2))
     W_HOST=$((W_HOST + 2))
     W_USER=$((W_USER + 2))
+    W_DESC=$((W_DESC + 2))
 }
 
 # === End DRY Helper Functions ===
@@ -201,12 +262,12 @@ list_connections() {
 
     # First pass: calculate column widths
     calculate_column_widths
-    local w_alias=$W_ALIAS w_host=$W_HOST w_user=$W_USER w_dir=$W_DIR
+    local w_alias=$W_ALIAS w_host=$W_HOST w_user=$W_USER w_dir=$W_DIR w_desc=$W_DESC
 
-    local total=$((w_alias + w_host + w_user + w_dir))
+    local total=$((w_alias + w_host + w_user + w_dir + w_desc))
 
     echo -e "${GREEN}=== SM - SSH Manager ${SM_VERSION} ===${NC}"
-    printf "%-${w_alias}s %-${w_host}s %-${w_user}s %-${w_dir}s\n" "ALIAS" "HOSTALIAS" "USER" "DIRECTORY"
+    printf "%-${w_alias}s %-${w_host}s %-${w_user}s %-${w_dir}s %-${w_desc}s\n" "ALIAS" "HOSTALIAS" "USER" "DIRECTORY" "DESCRIPTION"
     printf '%*s\n' "$total" '' | tr ' ' '-'
 
     while IFS='|' read -r alias host port user directory description key; do
@@ -220,9 +281,9 @@ list_connections() {
 
         # Highlight default (green row)
         if [[ "$alias" == "$default_conn" ]]; then
-            printf "${GREEN}%-${w_alias}s %-${w_host}s %-${w_user}s %-${w_dir}s${NC}\n" "$alias" "$hostalias" "$user" "$directory"
+            printf "${GREEN}%-${w_alias}s %-${w_host}s %-${w_user}s %-${w_dir}s %-${w_desc}s${NC}\n" "$alias" "$hostalias" "$user" "$directory" "$description"
         else
-            printf "%-${w_alias}s %-${w_host}s %-${w_user}s %-${w_dir}s\n" "$alias" "$hostalias" "$user" "$directory"
+            printf "%-${w_alias}s %-${w_host}s %-${w_user}s %-${w_dir}s %-${w_desc}s\n" "$alias" "$hostalias" "$user" "$directory" "$description"
         fi
     done < "$CONFIG_FILE"
 }
@@ -235,6 +296,7 @@ interactive_select() {
     local hostaliases=()
     local users=()
     local directories=()
+    local descriptions=()
 
     # Build arrays
     while IFS='|' read -r alias host port user directory description key; do
@@ -247,6 +309,7 @@ interactive_select() {
         hostaliases+=("$(get_host_alias "$host")")
         users+=("$user")
         directories+=("$directory")
+        descriptions+=("$description")
     done < "$CONFIG_FILE"
 
     local count=${#aliases[@]}
@@ -257,8 +320,8 @@ interactive_select() {
 
     # Calculate dynamic column widths
     calculate_column_widths
-    local w_alias=$W_ALIAS w_host=$W_HOST w_user=$W_USER w_dir=$W_DIR
-    local total=$((w_alias + w_host + w_user + w_dir + 2))
+    local w_alias=$W_ALIAS w_host=$W_HOST w_user=$W_USER w_dir=$W_DIR w_desc=$W_DESC
+    local total=$((w_alias + w_host + w_user + w_dir + w_desc + 2))
 
     # Find initial selection (default or first)
     local selected=0
@@ -287,7 +350,7 @@ interactive_select() {
         tput ed
 
         echo -e "${GREEN}=== SM - SSH Manager ${SM_VERSION} ===${NC}"
-        printf "%-${w_alias}s %-${w_host}s %-${w_user}s %-${w_dir}s\n" "ALIAS" "HOSTALIAS" "USER" "DIRECTORY"
+        printf "%-${w_alias}s %-${w_host}s %-${w_user}s %-${w_dir}s %-${w_desc}s\n" "ALIAS" "HOSTALIAS" "USER" "DIRECTORY" "DESCRIPTION"
         printf '%*s\n' "$total" '' | tr ' ' '-'
 
         local wa=$((w_alias - 2))
@@ -298,15 +361,15 @@ interactive_select() {
             if [[ $i -eq $selected ]]; then
                 # Selected row - inverse video
                 if [[ "$is_default" == "true" ]]; then
-                    printf "${GREEN}\e[7m> %-${wa}s %-${w_host}s %-${w_user}s %-${w_dir}s\e[27m${NC}\n" "${aliases[$i]}" "${hostaliases[$i]}" "${users[$i]}" "${directories[$i]}"
+                    printf "${GREEN}\e[7m> %-${wa}s %-${w_host}s %-${w_user}s %-${w_dir}s %-${w_desc}s\e[27m${NC}\n" "${aliases[$i]}" "${hostaliases[$i]}" "${users[$i]}" "${directories[$i]}" "${descriptions[$i]}"
                 else
-                    printf "\e[7m> %-${wa}s %-${w_host}s %-${w_user}s %-${w_dir}s\e[27m\n" "${aliases[$i]}" "${hostaliases[$i]}" "${users[$i]}" "${directories[$i]}"
+                    printf "\e[7m> %-${wa}s %-${w_host}s %-${w_user}s %-${w_dir}s %-${w_desc}s\e[27m\n" "${aliases[$i]}" "${hostaliases[$i]}" "${users[$i]}" "${directories[$i]}" "${descriptions[$i]}"
                 fi
             else
                 if [[ "$is_default" == "true" ]]; then
-                    printf "${GREEN}  %-${wa}s %-${w_host}s %-${w_user}s %-${w_dir}s${NC}\n" "${aliases[$i]}" "${hostaliases[$i]}" "${users[$i]}" "${directories[$i]}"
+                    printf "${GREEN}  %-${wa}s %-${w_host}s %-${w_user}s %-${w_dir}s %-${w_desc}s${NC}\n" "${aliases[$i]}" "${hostaliases[$i]}" "${users[$i]}" "${directories[$i]}" "${descriptions[$i]}"
                 else
-                    printf "  %-${wa}s %-${w_host}s %-${w_user}s %-${w_dir}s\n" "${aliases[$i]}" "${hostaliases[$i]}" "${users[$i]}" "${directories[$i]}"
+                    printf "  %-${wa}s %-${w_host}s %-${w_user}s %-${w_dir}s %-${w_desc}s\n" "${aliases[$i]}" "${hostaliases[$i]}" "${users[$i]}" "${directories[$i]}" "${descriptions[$i]}"
                 fi
             fi
         done
@@ -424,7 +487,7 @@ get_sessions_for_alias() {
     # Build timeout command array
     local ssh_cmd_timeout=("${ssh_cmd[0]}" "${SSH_QUERY_TIMEOUT_OPTS[@]}" "${ssh_cmd[@]:1}")
     # Get sessions from remote, strip ANSI codes, filter by alias pattern
-    timeout "$SSH_QUERY_MAX_SECS" "${ssh_cmd_timeout[@]}" "zellij list-sessions 2>/dev/null" 2>/dev/null | \
+    _timeout "$SSH_QUERY_MAX_SECS" "${ssh_cmd_timeout[@]}" "zellij list-sessions 2>/dev/null" 2>/dev/null | \
         sed 's/\x1b\[[0-9;]*m//g' | \
         grep -E "^${safe_alias}(_[0-9]+)?(\s|$)" | \
         awk '{print $1}'
@@ -471,7 +534,7 @@ is_session_exited() {
     local safe_session
     safe_session=$(regex_escape "$session")
     local ssh_cmd_timeout=("${ssh_cmd[0]}" "${SSH_QUERY_TIMEOUT_OPTS[@]}" "${ssh_cmd[@]:1}")
-    timeout "$SSH_QUERY_MAX_SECS" "${ssh_cmd_timeout[@]}" "zellij list-sessions 2>/dev/null" 2>/dev/null | grep -Eq "^${safe_session}.*EXITED"
+    _timeout "$SSH_QUERY_MAX_SECS" "${ssh_cmd_timeout[@]}" "zellij list-sessions 2>/dev/null" 2>/dev/null | grep -Eq "^${safe_session}.*EXITED"
 }
 
 # Cleanup dead/exited sessions for an alias
@@ -488,7 +551,7 @@ cleanup_dead_sessions() {
     while IFS= read -r line; do
         if [[ "$line" =~ ^(${safe_alias}(_[0-9]+)?).*EXITED ]]; then
             local dead_session="${BASH_REMATCH[1]}"
-            timeout "$SSH_QUERY_MAX_SECS" "${ssh_cmd_timeout[@]}" "zellij delete-session ${dead_session} --force 2>/dev/null" 2>/dev/null || true
+            _timeout "$SSH_QUERY_MAX_SECS" "${ssh_cmd_timeout[@]}" "zellij delete-session ${dead_session} --force 2>/dev/null" 2>/dev/null || true
         fi
     done <<< "$sessions"
 }
@@ -995,6 +1058,28 @@ run_ssh() {
 
 # Main
 main() {
+    # Pre-parse global flags before init_config (--help, --version, --no-color)
+    local args=()
+    for arg in "$@"; do
+        case "$arg" in
+            --help|-h)
+                show_help
+                exit 0
+                ;;
+            --version|-v)
+                echo "sm $SM_VERSION"
+                exit 0
+                ;;
+            --no-color)
+                RED='' GREEN='' YELLOW='' BLUE='' NC=''
+                ;;
+            *)
+                args+=("$arg")
+                ;;
+        esac
+    done
+    set -- "${args[@]+"${args[@]}"}"
+
     init_config
 
     # Get script name (for smd, sml detection)
@@ -1035,6 +1120,8 @@ main() {
                     exit 1
                 fi
                 set_default "$2"
+            elif [[ "$1" == "edit" ]]; then
+                "${EDITOR:-vi}" "$CONFIG_FILE"
             else
                 # Direct connection by alias
                 connect "$1"

--- a/sm
+++ b/sm
@@ -3,18 +3,20 @@
 # Quick SSH connection manager with zellij session persistence
 # Invoke as 'sml' for list mode
 
-# Version: MMDD-HHMM from last git push, or "dev" if not in repo
+# Version: YYMMDD-HHMM from HEAD commit
+#   clean + pushed  → 260214-1154         (release)
+#   clean + unpushed → 260214-1154-draft  (push pending)
+#   uncommitted     → 260214-1154-dirty   (uncommitted changes)
+# install.sh bakes the version string in at install time
 SM_VERSION="dev"
 _sm_dir="$(dirname "${BASH_SOURCE[0]:-$0}")"
 if git -C "$_sm_dir" rev-parse --git-dir &>/dev/null; then
-    _pushed=$(git -C "$_sm_dir" log -1 --format='%cd' --date=format:'%y%m%d-%H%S' origin/main 2>/dev/null || echo "")
-    if [[ -n "$_pushed" ]] && git -C "$_sm_dir" diff --quiet HEAD origin/main 2>/dev/null; then
-        SM_VERSION="$_pushed"
-    else
-        _head=$(git -C "$_sm_dir" log -1 --format='%cd' --date=format:'%y%m%d-%H%S' HEAD 2>/dev/null || echo "dev")
-        SM_VERSION="${_head}-draft"
+    SM_VERSION=$(git -C "$_sm_dir" log -1 --format='%cd' --date=format:'%y%m%d-%H%M' HEAD 2>/dev/null || echo "dev")
+    if ! git -C "$_sm_dir" diff --quiet HEAD 2>/dev/null || ! git -C "$_sm_dir" diff --cached --quiet HEAD 2>/dev/null; then
+        SM_VERSION="${SM_VERSION}-dirty"
+    elif ! git -C "$_sm_dir" diff --quiet HEAD "@{upstream}" 2>/dev/null; then
+        SM_VERSION="${SM_VERSION}-draft"
     fi
-    unset _pushed _head
 fi
 unset _sm_dir
 

--- a/sm
+++ b/sm
@@ -270,7 +270,16 @@ list_connections() {
     printf "%-${w_alias}s %-${w_host}s %-${w_user}s %-${w_dir}s %-${w_desc}s\n" "ALIAS" "HOSTALIAS" "USER" "DIRECTORY" "DESCRIPTION"
     printf '%*s\n' "$total" '' | tr ' ' '-'
 
-    while IFS='|' read -r alias host port user directory description key; do
+    while IFS= read -r raw_line; do
+        # Show group headers
+        if [[ "$raw_line" =~ ^#\ group:\ (.+)$ ]]; then
+            echo ""
+            echo -e "${BLUE}--- ${BASH_REMATCH[1]} ---${NC}"
+            continue
+        fi
+
+        IFS='|' read -r alias host port user directory description key <<< "$raw_line"
+
         # Skip comments, empty lines, host aliases, default
         [[ "$alias" =~ ^#.*$ ]] && continue
         [[ -z "$alias" ]] && continue
@@ -297,9 +306,18 @@ interactive_select() {
     local users=()
     local directories=()
     local descriptions=()
+    local groups=()
+    local current_group=""
 
     # Build arrays
-    while IFS='|' read -r alias host port user directory description key; do
+    while IFS= read -r raw_line; do
+        if [[ "$raw_line" =~ ^#\ group:\ (.+)$ ]]; then
+            current_group="${BASH_REMATCH[1]}"
+            continue
+        fi
+
+        IFS='|' read -r alias host port user directory description key <<< "$raw_line"
+
         [[ "$alias" =~ ^#.*$ ]] && continue
         [[ -z "$alias" ]] && continue
         [[ "$alias" =~ ^default= ]] && continue
@@ -310,6 +328,7 @@ interactive_select() {
         users+=("$user")
         directories+=("$directory")
         descriptions+=("$description")
+        groups+=("$current_group")
     done < "$CONFIG_FILE"
 
     local count=${#aliases[@]}
@@ -389,8 +408,14 @@ interactive_select() {
         if [[ $fi_count -eq 0 ]]; then
             echo -e "${YELLOW}  No matches${NC}"
         else
+            local last_group=""
             for fi_pos in "${!filtered_indices[@]}"; do
                 local i="${filtered_indices[$fi_pos]}"
+                # Show group header if group changed and not in filter mode
+                if [[ -z "$filter_text" && -n "${groups[$i]}" && "${groups[$i]}" != "$last_group" ]]; then
+                    echo -e "${BLUE}  --- ${groups[$i]} ---${NC}"
+                    last_group="${groups[$i]}"
+                fi
                 local is_default=false
                 [[ "${aliases[$i]}" == "$default_conn" ]] && is_default=true
 
@@ -1337,6 +1362,143 @@ validate_config() {
     fi
 }
 
+# Add a new connection via interactive wizard
+add_connection() {
+    echo -e "${GREEN}=== Add New Connection ===${NC}"
+    echo ""
+
+    local alias host port user directory description key
+
+    read -p "Alias (unique name, e.g. myserver): " alias
+    if [[ -z "$alias" ]] || [[ "$alias" == *"|"* ]]; then
+        echo -e "${RED}Error: Alias cannot contain '|' or be empty${NC}"
+        exit 1
+    fi
+    # Check for duplicate
+    if awk -F'|' -v key="$alias" '$1 == key {found=1; exit} END {exit !found}' "$CONFIG_FILE" 2>/dev/null; then
+        echo -e "${RED}Error: Connection '$alias' already exists.${NC}"
+        exit 1
+    fi
+
+    read -p "Host (hostname or IP): " host
+    if [[ -z "$host" ]]; then
+        echo -e "${RED}Host is required.${NC}"
+        exit 1
+    fi
+
+    read -p "Port [22]: " port
+    port="${port:-22}"
+    if ! validate_port "$port" "$alias"; then
+        exit 1
+    fi
+
+    read -p "User: " user
+    if [[ -z "$user" ]]; then
+        echo -e "${RED}User is required.${NC}"
+        exit 1
+    fi
+
+    read -p "Directory (optional, remote path after login): " directory
+    read -p "Description (optional): " description
+    read -p "SSH key path (optional, e.g. ~/.ssh/id_rsa): " key
+
+    # Validate no fields contain the config delimiter
+    if [[ "$host" == *"|"* ]] || [[ "$user" == *"|"* ]] || [[ "$description" == *"|"* ]] || [[ "$directory" == *"|"* ]] || [[ "$key" == *"|"* ]]; then
+        echo -e "${RED}Error: Fields cannot contain '|' (config delimiter)${NC}"
+        exit 1
+    fi
+
+    local line="${alias}|${host}|${port}|${user}|${directory}|${description}|${key}"
+    echo "$line" >> "$CONFIG_FILE"
+    echo -e "${GREEN}Connection '$alias' added.${NC}"
+}
+
+# Remove a connection by alias
+remove_connection() {
+    local alias="$1"
+
+    if ! awk -F'|' -v key="$alias" '$1 == key {found=1; exit} END {exit !found}' "$CONFIG_FILE"; then
+        echo -e "${RED}Error: Connection '$alias' not found.${NC}"
+        exit 1
+    fi
+
+    read -p "Remove connection '$alias'? [y/N] " confirm
+    if [[ "$confirm" != "y" && "$confirm" != "Y" ]]; then
+        echo -e "${BLUE}Cancelled.${NC}"
+        exit 0
+    fi
+
+    # Remove the line matching the alias (exact match on first field)
+    awk -F'|' -v key="$alias" '$1 != key' "$CONFIG_FILE" > "${CONFIG_FILE}.tmp" && mv "${CONFIG_FILE}.tmp" "$CONFIG_FILE"
+    echo -e "${GREEN}Connection '$alias' removed.${NC}"
+}
+
+# Output shell completions
+generate_completions() {
+    local shell="${1:-bash}"
+
+    case "$shell" in
+        bash)
+            cat <<'COMPEOF'
+# SM bash completions - source this or add to ~/.bashrc
+_sm_completions() {
+    local cur prev commands
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    prev="${COMP_WORDS[COMP_CWORD-1]}"
+    commands="list set edit test validate doctor auth parallel reset sessions add remove completions"
+
+    case "$prev" in
+        sm)
+            COMPREPLY=($(compgen -W "$commands --help --version --no-color" -- "$cur"))
+            return
+            ;;
+        set|test|auth|parallel|reset|sessions|remove)
+            local aliases
+            aliases=$(awk -F'|' '!/^(#|$|default=|hostalias:)/ {print $1}' ~/.config/sm/connections.conf 2>/dev/null)
+            COMPREPLY=($(compgen -W "$aliases" -- "$cur"))
+            return
+            ;;
+        completions)
+            COMPREPLY=($(compgen -W "bash zsh" -- "$cur"))
+            return
+            ;;
+    esac
+}
+complete -F _sm_completions sm
+COMPEOF
+            ;;
+        zsh)
+            cat <<'COMPEOF'
+# SM zsh completions - source this or add to ~/.zshrc
+_sm() {
+    local commands aliases
+    commands=(list set edit test validate doctor auth parallel reset sessions add remove completions --help --version --no-color)
+    aliases=(${(f)"$(awk -F'|' '!/^(#|$|default=|hostalias:)/ {print $1}' ~/.config/sm/connections.conf 2>/dev/null)"})
+
+    if (( CURRENT == 2 )); then
+        _describe 'command' commands
+        _describe 'alias' aliases
+    elif (( CURRENT == 3 )); then
+        case "$words[2]" in
+            set|test|auth|parallel|reset|sessions|remove)
+                _describe 'alias' aliases
+                ;;
+            completions)
+                _describe 'shell' '(bash zsh)'
+                ;;
+        esac
+    fi
+}
+compdef _sm sm
+COMPEOF
+            ;;
+        *)
+            echo -e "${RED}Unknown shell: $shell (use 'bash' or 'zsh')${NC}"
+            exit 1
+            ;;
+    esac
+}
+
 # Main
 main() {
     # Pre-parse global flags before init_config (--help, --version, --no-color)
@@ -1360,6 +1522,12 @@ main() {
         esac
     done
     set -- "${args[@]+"${args[@]}"}"
+
+    # Commands that don't need config
+    if [[ $# -ge 1 && "$1" == "completions" ]]; then
+        generate_completions "${2:-bash}"
+        exit 0
+    fi
 
     init_config
 
@@ -1437,6 +1605,14 @@ main() {
                     exit 1
                 fi
                 list_and_connect "$2"
+            elif [[ "$1" == "add" ]]; then
+                add_connection
+            elif [[ "$1" == "remove" || "$1" == "rm" ]]; then
+                if [[ $# -lt 2 ]]; then
+                    echo -e "${RED}Usage: sm remove <alias>${NC}"
+                    exit 1
+                fi
+                remove_connection "$2"
             else
                 # Direct connection by alias
                 connect "$1"

--- a/sm2
+++ b/sm2
@@ -176,9 +176,9 @@ sanitize_session_name() {
 }
 
 # Escape a string for safe embedding inside double quotes in a remote shell command
-# Escapes: \ " $ `
+# Escapes: \ " $ ` !
 shell_escape_double() {
-    printf '%s' "$1" | sed 's/[\\\"$`]/\\&/g'
+    printf '%s' "$1" | sed 's/[\\\"$`!]/\\&/g'
 }
 
 # Build cd command string for remote execution
@@ -229,6 +229,7 @@ SSH_QUERY_MAX_SECS=10  # hard kill for entire ssh query call
 init_config() {
     if [[ ! -d "$CONFIG_DIR" ]]; then
         mkdir -p "$CONFIG_DIR"
+        chmod 700 "$CONFIG_DIR"
     fi
 
     if [[ ! -f "$CONFIG_FILE" ]]; then
@@ -247,6 +248,7 @@ init_config() {
 # default=sm231
 
 EOF
+        chmod 600 "$CONFIG_FILE"
         echo -e "${YELLOW}Config file created: $CONFIG_FILE${NC}"
         echo -e "${YELLOW}Please edit it to add your connections.${NC}"
         exit 0
@@ -535,7 +537,7 @@ interactive_select() {
                     local real_idx
                     real_idx=$(get_selected_real_index)
                     tput cnorm
-                    connect "${aliases[$real_idx]}"
+                    connect "${aliases[$real_idx]}" || true
                     rebuild_filter
                     selected=$default_selected
                     redraw_menu
@@ -604,7 +606,7 @@ interactive_select() {
                 local real_idx
                 real_idx=$(get_selected_real_index)
                 tput cnorm
-                connect "${aliases[$real_idx]}"
+                connect "${aliases[$real_idx]}" || true
                 filter_text=""
                 rebuild_filter
                 selected=$default_selected
@@ -616,7 +618,7 @@ interactive_select() {
                 local real_idx
                 real_idx=$(get_selected_real_index)
                 tput cnorm
-                connect "${aliases[$real_idx]}"
+                connect "${aliases[$real_idx]}" || true
                 filter_text=""
                 rebuild_filter
                 selected=$default_selected
@@ -628,7 +630,7 @@ interactive_select() {
                 local real_idx
                 real_idx=$(get_selected_real_index)
                 tput cnorm
-                connect_zellij "${aliases[$real_idx]}"
+                connect_zellij "${aliases[$real_idx]}" || true
                 filter_text=""
                 rebuild_filter
                 selected=$default_selected
@@ -639,7 +641,7 @@ interactive_select() {
                 local real_idx
                 real_idx=$(get_selected_real_index)
                 tput cnorm
-                connect_auth "${aliases[$real_idx]}"
+                connect_auth "${aliases[$real_idx]}" || true
                 filter_text=""
                 rebuild_filter
                 selected=$default_selected
@@ -650,7 +652,7 @@ interactive_select() {
                 local real_idx
                 real_idx=$(get_selected_real_index)
                 tput cnorm
-                connect_parallel "${aliases[$real_idx]}"
+                connect_parallel "${aliases[$real_idx]}" || true
                 filter_text=""
                 rebuild_filter
                 selected=$default_selected
@@ -661,7 +663,7 @@ interactive_select() {
                 local real_idx
                 real_idx=$(get_selected_real_index)
                 tput cnorm
-                connect_hard_reset "${aliases[$real_idx]}" --force
+                connect_hard_reset "${aliases[$real_idx]}" --force || true
                 filter_text=""
                 rebuild_filter
                 selected=$default_selected
@@ -672,7 +674,7 @@ interactive_select() {
                 local real_idx
                 real_idx=$(get_selected_real_index)
                 tput cnorm
-                list_and_connect "${aliases[$real_idx]}"
+                list_and_connect "${aliases[$real_idx]}" || true
                 filter_text=""
                 rebuild_filter
                 selected=$default_selected
@@ -763,9 +765,9 @@ is_session_alive() {
     shift
     local ssh_cmd=("$@")
     local safe_session
-    safe_session=$(regex_escape "$session")
+    safe_session=$(sanitize_session_name "$session")
     local ssh_cmd_timeout=("${ssh_cmd[0]}" "${SSH_QUERY_TIMEOUT_OPTS[@]}" "${ssh_cmd[@]:1}")
-    _timeout "$SSH_QUERY_MAX_SECS" "${ssh_cmd_timeout[@]}" "tmux has-session -t '${session}' 2>/dev/null && echo ALIVE" 2>/dev/null | grep -q "ALIVE"
+    _timeout "$SSH_QUERY_MAX_SECS" "${ssh_cmd_timeout[@]}" "tmux has-session -t '${safe_session}' 2>/dev/null && echo ALIVE" 2>/dev/null | grep -q "ALIVE"
 }
 
 # Cleanup dead sessions for an alias
@@ -1437,8 +1439,8 @@ add_connection() {
     local alias host port user directory description key
 
     read -p "Alias (unique name, e.g. myserver): " alias
-    if [[ -z "$alias" ]] || [[ "$alias" == *"|"* ]]; then
-        echo -e "${RED}Error: Alias cannot contain '|' or be empty${NC}"
+    if [[ -z "$alias" ]] || [[ ! "$alias" =~ ^[A-Za-z0-9_.-]+$ ]]; then
+        echo -e "${RED}Error: Alias must contain only letters, digits, dash, underscore, or dot${NC}"
         exit 1
     fi
     # Check for duplicate
@@ -1452,6 +1454,10 @@ add_connection() {
         echo -e "${RED}Host is required.${NC}"
         exit 1
     fi
+    if [[ "$host" =~ [[:space:]\;\`\$\(\)\{\}\|\'\"\\] ]]; then
+        echo -e "${RED}Error: Host contains invalid characters${NC}"
+        exit 1
+    fi
 
     read -p "Port [22]: " port
     port="${port:-22}"
@@ -1462,6 +1468,10 @@ add_connection() {
     read -p "User: " user
     if [[ -z "$user" ]]; then
         echo -e "${RED}User is required.${NC}"
+        exit 1
+    fi
+    if [[ "$user" =~ [[:space:]\;\`\$\(\)\{\}\|\'\"\\] ]]; then
+        echo -e "${RED}Error: User contains invalid characters${NC}"
         exit 1
     fi
 

--- a/sm2
+++ b/sm2
@@ -499,7 +499,7 @@ interactive_select() {
             # Search mode key handling
             if [[ "$key" == $'\x1b' ]]; then
                 read -rsn2 -t 0.1 seq || true
-                if [[ "$seq" == '[A' ]]; then
+                if [[ "$seq" == '[A' || "$seq" == 'OA' ]]; then
                     # Up arrow in search mode
                     if [[ $fi_count -gt 0 ]]; then
                         if [[ $selected -gt 0 ]]; then
@@ -509,7 +509,7 @@ interactive_select() {
                         fi
                     fi
                     draw_menu
-                elif [[ "$seq" == '[B' ]]; then
+                elif [[ "$seq" == '[B' || "$seq" == 'OB' ]]; then
                     # Down arrow in search mode
                     if [[ $fi_count -gt 0 ]]; then
                         if [[ $selected -lt $((fi_count - 1)) ]]; then
@@ -563,8 +563,9 @@ interactive_select() {
         # Normal mode key handling
         if [[ "$key" == $'\x1b' ]]; then
             # Escape sequence - read more
+            # Handle both normal mode ([A/[B) and application mode (OA/OB) arrow keys
             read -rsn2 -t 0.1 seq || true
-            if [[ "$seq" == '[A' ]]; then
+            if [[ "$seq" == '[A' || "$seq" == 'OA' ]]; then
                 # Up arrow - wrap to bottom
                 if [[ $fi_count -gt 0 ]]; then
                     if [[ $selected -gt 0 ]]; then
@@ -574,7 +575,7 @@ interactive_select() {
                     fi
                 fi
                 draw_menu
-            elif [[ "$seq" == '[B' ]]; then
+            elif [[ "$seq" == '[B' || "$seq" == 'OB' ]]; then
                 # Down arrow - wrap to top
                 if [[ $fi_count -gt 0 ]]; then
                     if [[ $selected -lt $((fi_count - 1)) ]]; then
@@ -729,13 +730,6 @@ get_sessions_for_alias() {
 }
 
 # Count sessions for an alias
-count_sessions_for_alias() {
-    local alias="$1"
-    shift
-    local ssh_cmd=("$@")
-    get_sessions_for_alias "$alias" "${ssh_cmd[@]}" | wc -l
-}
-
 # Get next parallel session name
 get_next_session_name() {
     local alias="$1"
@@ -918,7 +912,7 @@ list_and_connect() {
 
         if [[ "$key" == $'\x1b' ]]; then
             read -rsn2 -t 0.1 seq || true
-            if [[ "$seq" == '[A' ]]; then
+            if [[ "$seq" == '[A' || "$seq" == 'OA' ]]; then
                 # Up arrow
                 if [[ $selected -gt 0 ]]; then
                     selected=$((selected - 1))
@@ -926,7 +920,7 @@ list_and_connect() {
                     selected=$((count - 1))
                 fi
                 draw_sessions
-            elif [[ "$seq" == '[B' ]]; then
+            elif [[ "$seq" == '[B' || "$seq" == 'OB' ]]; then
                 # Down arrow
                 if [[ $selected -lt $((count - 1)) ]]; then
                     selected=$((selected + 1))
@@ -1087,13 +1081,12 @@ connect() {
     local cd_cmd
     cd_cmd=$(build_cd_cmd "$directory")
 
-    # tmux auto-cleans dead sessions, but still count active ones
+    # Single SSH query: get sessions and derive count
     echo -e "${YELLOW}Checking sessions...${NC}"
-    cleanup_dead_sessions "$alias" "${ssh_cmd[@]}"
-
-    # Count remaining sessions
+    local sessions
+    sessions=$(get_sessions_for_alias "$alias" "${ssh_cmd[@]}")
     local session_count
-    session_count=$(count_sessions_for_alias "$alias" "${ssh_cmd[@]}")
+    session_count=$(echo "$sessions" | grep -c . || echo "0")
 
     if [[ $session_count -gt 1 ]]; then
         # Multiple sessions exist -> go to session submenu
@@ -1102,9 +1095,7 @@ connect() {
         return $?
     fi
 
-    # Get existing session or use primary name
-    local sessions
-    sessions=$(get_sessions_for_alias "$alias" "${ssh_cmd[@]}")
+    # Use existing session or primary name
     local session_name
     if [[ $session_count -eq 1 ]]; then
         session_name=$(echo "$sessions" | head -1)

--- a/sm2
+++ b/sm2
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
-# SM - SSH Manager
-# Quick SSH connection manager with zellij session persistence
-# Invoke as 'sml' for list mode
+# SM2 - SSH Manager (tmux edition)
+# Quick SSH connection manager with tmux session persistence
+# Invoke as 'sm2l' for list mode
 
 # Version: YYMMDD-HHMM from HEAD commit
 #   clean + pushed  → 260214-1154         (release)
@@ -56,30 +56,41 @@ _timeout() {
 # Show usage information
 show_help() {
     cat <<'HELPEOF'
-SM - SSH Manager
-Quick SSH connection manager with zellij session persistence.
+SM2 - SSH Manager (tmux edition)
+Quick SSH connection manager with tmux session persistence.
 
 Usage:
-  sm                          Interactive connection selector
-  sm <alias>                  Connect to alias directly
-  sm list                     List all connections
-  sm set <alias>              Set default connection
-  sm edit                     Open config in $EDITOR
-  sm test <alias>             Test SSH connectivity
-  sm validate                 Validate config file
-  sm add                      Add a new connection (wizard)
-  sm remove <alias>           Remove a connection
-  sm auth <alias>             Connect with auth port forwarding (1455)
-  sm parallel <alias>         Create a new parallel session
-  sm reset <alias> [--force]  Hard reset sessions for alias
-  sm sessions <alias>         List and select sessions on server
-  sm completions [bash|zsh]   Output shell completion script
-  sm --help, -h               Show this help
-  sm --version, -v            Show version
+  sm2                          Interactive connection selector
+  sm2 <alias>                  Connect to alias directly
+  sm2 list                     List all connections
+  sm2 set <alias>              Set default connection
+  sm2 edit                     Open config in $EDITOR
+  sm2 test <alias>             Test SSH connectivity
+  sm2 validate                 Validate config file
+  sm2 add                      Add a new connection (wizard)
+  sm2 remove <alias>           Remove a connection
+  sm2 auth <alias>             Connect with auth port forwarding (1455)
+  sm2 parallel <alias>         Create a new parallel session
+  sm2 reset <alias> [--force]  Hard reset sessions for alias
+  sm2 sessions <alias>         List and select sessions on server
+  sm2 completions [bash|zsh]   Output shell completion script
+  sm2 --help, -h               Show this help
+  sm2 --version, -v            Show version
 
 Shortcuts:
-  smd                         Connect to default connection
-  sml                         List sessions on default server
+  sm2d                         Connect to default connection
+  sm2l                         List sessions on default server
+
+Interactive keys:
+  Enter / T  Connect via tmux (default)
+  Z          Connect via Zellij (legacy fallback)
+  P          Create parallel tmux session
+  L          List tmux sessions on server
+  H          Hard reset tmux sessions
+  A          Connect with auth port forwarding
+  D          Set as default connection
+  /          Search/filter connections
+  Q / Esc    Quit
 
 Config: ~/.config/sm/connections.conf
 Format: alias|host|port|user|directory|description|[ssh_key]
@@ -158,10 +169,28 @@ build_ssh_cmd() {
     SSH_CMD+=("${RMATE_FORWARD[@]}" -p "$port" "${user}@${host}")
 }
 
+# Sanitize a string for safe use as a tmux/zellij session name
+# Strips everything except alphanumeric, dash, underscore, dot
+sanitize_session_name() {
+    printf '%s' "$1" | tr -cd 'A-Za-z0-9_.-'
+}
+
+# Escape a string for safe embedding inside double quotes in a remote shell command
+# Escapes: \ " $ `
+shell_escape_double() {
+    printf '%s' "$1" | sed 's/[\\\"$`]/\\&/g'
+}
+
 # Build cd command string for remote execution
 build_cd_cmd() {
     local directory="$1"
-    [[ -n "$directory" ]] && echo "cd \"${directory}\" 2>/dev/null; " || echo ""
+    if [[ -n "$directory" ]]; then
+        local escaped
+        escaped=$(shell_escape_double "$directory")
+        echo "cd \"${escaped}\" 2>/dev/null; "
+    else
+        echo ""
+    fi
 }
 
 # Calculate column widths for connection display, sets W_* globals
@@ -186,12 +215,6 @@ calculate_column_widths() {
 }
 
 # === End DRY Helper Functions ===
-
-# Zellij mouse configuration
-# - Pane selection with mouse requires mouse_mode true (zellij default)
-# - Shift+RightClick paste depends on terminal emulator (Windows Terminal: use Ctrl+Shift+V)
-# - Ctrl+V paste works via zellij clipboard passthrough
-ZELLIJ_MOUSE_FIX=''
 
 # rmate reverse port forwarding (allows editing remote files with local editor)
 # Usage on server: rmate filename.txt
@@ -268,7 +291,7 @@ list_connections() {
 
     local total=$((w_alias + w_host + w_user + w_dir + w_desc))
 
-    echo -e "${GREEN}=== SM - SSH Manager ${SM_VERSION} ===${NC}"
+    echo -e "${GREEN}=== SM2 - SSH Manager (tmux) ${SM_VERSION} ===${NC}"
     printf "%-${w_alias}s %-${w_host}s %-${w_user}s %-${w_dir}s %-${w_desc}s\n" "ALIAS" "HOSTALIAS" "USER" "DIRECTORY" "DESCRIPTION"
     printf '%*s\n' "$total" '' | tr ' ' '-'
 
@@ -397,7 +420,7 @@ interactive_select() {
         tput cup 0 0
         tput ed
 
-        echo -e "${GREEN}=== SM - SSH Manager ${SM_VERSION} ===${NC}"
+        echo -e "${GREEN}=== SM2 - SSH Manager (tmux) ${SM_VERSION} ===${NC}"
         if [[ "$search_mode" == "true" || -n "$filter_text" ]]; then
             echo -e "${BLUE}Filter: ${filter_text}_${NC}"
         fi
@@ -442,7 +465,7 @@ interactive_select() {
         if [[ "$search_mode" == "true" ]]; then
             echo -e "${YELLOW}Type to filter | Backspace: delete | Esc: clear filter | Enter: select${NC}"
         else
-            echo -e "${YELLOW}↑↓ Navigate | Enter: Connect | /: Search | A: Auth | P: Parallel | L: List | H: Hard Reset | D: Default | Q: Exit${NC}"
+            echo -e "${YELLOW}↑↓ Navigate | Enter/T: tmux | Z: Zellij | A: Auth | P: Parallel | L: List | H: Hard Reset | D: Default | Q: Exit${NC}"
         fi
     }
 
@@ -574,12 +597,36 @@ interactive_select() {
             selected=0
             draw_menu
         elif [[ "$key" == '' ]]; then
-            # Enter key - connect with zellij session restore
+            # Enter key - connect with tmux session restore
             if [[ $fi_count -gt 0 ]]; then
                 local real_idx
                 real_idx=$(get_selected_real_index)
                 tput cnorm
                 connect "${aliases[$real_idx]}"
+                filter_text=""
+                rebuild_filter
+                selected=0
+                redraw_menu
+            fi
+        elif [[ "$key" == 't' || "$key" == 'T' ]]; then
+            # T key - explicit tmux connect (same as Enter)
+            if [[ $fi_count -gt 0 ]]; then
+                local real_idx
+                real_idx=$(get_selected_real_index)
+                tput cnorm
+                connect "${aliases[$real_idx]}"
+                filter_text=""
+                rebuild_filter
+                selected=0
+                redraw_menu
+            fi
+        elif [[ "$key" == 'z' || "$key" == 'Z' ]]; then
+            # Z key - Zellij fallback
+            if [[ $fi_count -gt 0 ]]; then
+                local real_idx
+                real_idx=$(get_selected_real_index)
+                tput cnorm
+                connect_zellij "${aliases[$real_idx]}"
                 filter_text=""
                 rebuild_filter
                 selected=0
@@ -664,9 +711,9 @@ set_default() {
     echo -e "${GREEN}Default set to: $new_default${NC}"
 }
 
-# === Session Helper Functions ===
+# === Session Helper Functions (tmux) ===
 
-# Get all sessions for an alias (supports parallel sessions like alias, alias_2, alias_3)
+# Get all tmux sessions for an alias (supports parallel sessions like alias, alias_2, alias_3)
 # Runs locally - queries remote server via SSH
 get_sessions_for_alias() {
     local alias="$1"
@@ -676,11 +723,9 @@ get_sessions_for_alias() {
     safe_alias=$(regex_escape "$alias")
     # Build timeout command array
     local ssh_cmd_timeout=("${ssh_cmd[0]}" "${SSH_QUERY_TIMEOUT_OPTS[@]}" "${ssh_cmd[@]:1}")
-    # Get sessions from remote, strip ANSI codes, filter by alias pattern
-    _timeout "$SSH_QUERY_MAX_SECS" "${ssh_cmd_timeout[@]}" "zellij list-sessions 2>/dev/null" 2>/dev/null | \
-        sed 's/\x1b\[[0-9;]*m//g' | \
-        grep -E "^${safe_alias}(_[0-9]+)?(\s|$)" | \
-        awk '{print $1}'
+    # Get tmux sessions from remote - clean output with -F format (no ANSI stripping needed)
+    _timeout "$SSH_QUERY_MAX_SECS" "${ssh_cmd_timeout[@]}" "tmux list-sessions -F '#{session_name}' 2>/dev/null" 2>/dev/null | \
+        grep -E "^${safe_alias}(_[0-9]+)?$" || true
 }
 
 # Count sessions for an alias
@@ -716,37 +761,28 @@ get_next_session_name() {
     fi
 }
 
-# Check if a specific session is exited/dead
-is_session_exited() {
+# Check if a specific tmux session exists on the remote
+# Returns 0 if session exists, 1 if not
+is_session_alive() {
     local session="$1"
     shift
     local ssh_cmd=("$@")
     local safe_session
     safe_session=$(regex_escape "$session")
     local ssh_cmd_timeout=("${ssh_cmd[0]}" "${SSH_QUERY_TIMEOUT_OPTS[@]}" "${ssh_cmd[@]:1}")
-    _timeout "$SSH_QUERY_MAX_SECS" "${ssh_cmd_timeout[@]}" "zellij list-sessions 2>/dev/null" 2>/dev/null | grep -Eq "^${safe_session}.*EXITED"
+    _timeout "$SSH_QUERY_MAX_SECS" "${ssh_cmd_timeout[@]}" "tmux has-session -t '${session}' 2>/dev/null && echo ALIVE" 2>/dev/null | grep -q "ALIVE"
 }
 
-# Cleanup dead/exited sessions for an alias
+# Cleanup dead sessions for an alias
+# tmux auto-cleans dead sessions, so this is a no-op
+# Kept for API compatibility with connect() flow
 cleanup_dead_sessions() {
-    local alias="$1"
-    shift
-    local ssh_cmd=("$@")
-    local safe_alias
-    safe_alias=$(regex_escape "$alias")
-    local ssh_cmd_timeout=("${ssh_cmd[0]}" "${SSH_QUERY_TIMEOUT_OPTS[@]}" "${ssh_cmd[@]:1}")
-    local sessions
-    sessions=$(timeout "$SSH_QUERY_MAX_SECS" "${ssh_cmd_timeout[@]}" "zellij list-sessions 2>/dev/null" 2>/dev/null | sed 's/\x1b\[[0-9;]*m//g')
-
-    while IFS= read -r line; do
-        if [[ "$line" =~ ^(${safe_alias}(_[0-9]+)?).*EXITED ]]; then
-            local dead_session="${BASH_REMATCH[1]}"
-            _timeout "$SSH_QUERY_MAX_SECS" "${ssh_cmd_timeout[@]}" "zellij delete-session ${dead_session} --force 2>/dev/null" 2>/dev/null || true
-        fi
-    done <<< "$sessions"
+    # tmux automatically removes sessions when all windows/panes close
+    # No manual cleanup needed
+    true
 }
 
-# Delete all sessions for an alias
+# Delete all tmux sessions for an alias
 delete_all_sessions_for_alias() {
     local alias="$1"
     shift
@@ -756,13 +792,13 @@ delete_all_sessions_for_alias() {
     sessions=$(get_sessions_for_alias "$alias" "${ssh_cmd[@]}")
 
     while IFS= read -r session; do
-        [[ -n "$session" ]] && "${ssh_cmd_timeout[@]}" "zellij delete-session ${session} --force 2>/dev/null" 2>/dev/null || true
+        [[ -n "$session" ]] && "${ssh_cmd_timeout[@]}" "tmux kill-session -t '${session}' 2>/dev/null" 2>/dev/null || true
     done <<< "$sessions"
 }
 
 # === End Session Helper Functions ===
 
-# List sessions on server and connect to selected one
+# List tmux sessions on server and connect to selected one
 list_and_connect() {
     local alias="$1"
     local auth_mode="${2:-}"  # Optional: "auth" for port forwarding mode
@@ -794,14 +830,14 @@ list_and_connect() {
     cd_cmd=$(build_cd_cmd "$directory")
 
     echo -e "${GREEN}=== Sessions on $alias ($description) ===${NC}"
-    echo -e "${YELLOW}Fetching sessions...${NC}"
+    echo -e "${YELLOW}Fetching tmux sessions...${NC}"
 
-    # Get sessions from server (strip ANSI color codes) - filter by alias pattern
+    # Get tmux sessions from server
     local sessions
     sessions=$(get_sessions_for_alias "$alias" "${ssh_cmd[@]}")
 
     if [[ -z "$sessions" ]]; then
-        echo -e "${RED}No sessions found for '$alias'.${NC}"
+        echo -e "${RED}No tmux sessions found for '$alias'.${NC}"
         read -p "Create new session '$alias'? [Y/n/b=back] " confirm
         if [[ "$confirm" == "n" || "$confirm" == "N" ]]; then
             exit_or_return 0 "$stay_interactive"; return 0
@@ -810,8 +846,10 @@ list_and_connect() {
         fi
         local final_ssh=("${ssh_cmd[@]}")
         [[ "$auth_mode" == "auth" ]] && final_ssh=("${ssh_cmd_auth[@]}")
+        local safe_alias_new
+        safe_alias_new=$(sanitize_session_name "$alias")
         set_terminal_title "$(build_connection_title "$user" "$host" "$description")"
-        "${final_ssh[@]}" -t "${ZELLIJ_MOUSE_FIX}${cd_cmd}zellij attach -c ${alias}"
+        "${final_ssh[@]}" -t "command -v tmux >/dev/null 2>&1 || { echo 'Error: tmux is not installed on this server. Install with: sudo apt install tmux'; exit 1; }; ${cd_cmd}tmux new-session -A -s '${safe_alias_new}'"
         reset_terminal
         exit_or_return 0 "$stay_interactive"; return 0
     fi
@@ -835,20 +873,12 @@ list_and_connect() {
     tput civis
     trap cleanup EXIT INT TERM HUP
 
-    # Cache session status once (avoid SSH call per session per redraw)
-    local ssh_cmd_timeout=("${ssh_cmd[0]}" "${SSH_QUERY_TIMEOUT_OPTS[@]}" "${ssh_cmd[@]:1}")
-    local _cached_session_list=""
-    refresh_session_cache() {
-        _cached_session_list=$(timeout "$SSH_QUERY_MAX_SECS" "${ssh_cmd_timeout[@]}" "zellij list-sessions 2>/dev/null" 2>/dev/null | sed 's/\x1b\[[0-9;]*m//g' || echo "")
-    }
-    refresh_session_cache
-
-    # Draw function
+    # Draw function (tmux sessions don't have EXITED state, so all listed sessions are active)
     draw_sessions() {
         tput cup 0 0
         tput ed
 
-        echo -e "${GREEN}=== Sessions for $alias ($description) ===${NC}"
+        echo -e "${GREEN}=== tmux sessions for $alias ($description) ===${NC}"
         if [[ "$auth_mode" == "auth" ]]; then
             echo -e "${YELLOW}[Auth Mode: Port 1455 forwarding enabled]${NC}"
         fi
@@ -857,26 +887,17 @@ list_and_connect() {
         for i in "${!session_array[@]}"; do
             local session="${session_array[$i]}"
             local is_new=false
-            local is_exited=false
             [[ "$session" == "[NEW]"* ]] && is_new=true
-            # Check cached session list for exited status
-            local safe_session
-            safe_session=$(regex_escape "$session")
-            echo "$_cached_session_list" | grep -Eq "^${safe_session}.*EXITED" && is_exited=true
 
             if [[ $i -eq $selected ]]; then
                 if [[ "$is_new" == "true" ]]; then
                     printf "${BLUE}\e[7m> %s\e[27m${NC}\n" "$session"
-                elif [[ "$is_exited" == "true" ]]; then
-                    printf "${RED}\e[7m> %s (EXITED)\e[27m${NC}\n" "$session"
                 else
                     printf "${GREEN}\e[7m> %s\e[27m${NC}\n" "$session"
                 fi
             else
                 if [[ "$is_new" == "true" ]]; then
                     printf "${BLUE}  %s${NC}\n" "$session"
-                elif [[ "$is_exited" == "true" ]]; then
-                    printf "${RED}  %s (EXITED)${NC}\n" "$session"
                 else
                     printf "${GREEN}  %s${NC}\n" "$session"
                 fi
@@ -929,11 +950,13 @@ list_and_connect() {
                 exit_or_return 0 "$stay_interactive"; return 0
             else
                 local session_name="$selected_session"
-                echo -e "${GREEN}Connecting to session '$session_name'...${NC}"
+                local safe_sname
+                safe_sname=$(sanitize_session_name "$session_name")
+                echo -e "${GREEN}Connecting to tmux session '$safe_sname'...${NC}"
                 local final_ssh=("${ssh_cmd[@]}")
                 [[ "$auth_mode" == "auth" ]] && final_ssh=("${ssh_cmd_auth[@]}")
                 set_terminal_title "$(build_connection_title "$user" "$host" "$description")"
-                "${final_ssh[@]}" -t "${ZELLIJ_MOUSE_FIX}${cd_cmd}zellij attach ${session_name}"
+                "${final_ssh[@]}" -t "${cd_cmd}tmux attach-session -t '${safe_sname}'"
                 reset_terminal
                 exit_or_return 0 "$stay_interactive"; return 0
             fi
@@ -960,7 +983,7 @@ list_and_connect() {
     done
 }
 
-# Hard reset - delete session(s) and create fresh
+# Hard reset - delete tmux session(s) and create fresh
 # Args: alias [specific_session] [--force]
 connect_hard_reset() {
     local alias="$1"
@@ -999,10 +1022,12 @@ connect_hard_reset() {
 
     # If specific session provided (from submenu H), reset only that one
     if [[ -n "$specific_session" ]]; then
-        echo -e "${GREEN}Hard Reset: $specific_session${NC}"
-        echo -e "${YELLOW}Deleting session '${specific_session}' and creating fresh...${NC}"
+        local safe_session
+        safe_session=$(sanitize_session_name "$specific_session")
+        echo -e "${GREEN}Hard Reset: $safe_session${NC}"
+        echo -e "${YELLOW}Killing tmux session '${safe_session}' and creating fresh...${NC}"
         echo ""
-        local remote_cmd="zellij delete-session ${specific_session} --force 2>/dev/null; ${cd_cmd}zellij attach -c ${specific_session}"
+        local remote_cmd="tmux kill-session -t '${safe_session}' 2>/dev/null; ${cd_cmd}tmux new-session -A -s '${safe_session}'"
         set_terminal_title "$(build_connection_title "$user" "$host" "$description")"
         "${ssh_cmd[@]}" -t "$remote_cmd"
         reset_terminal
@@ -1011,7 +1036,7 @@ connect_hard_reset() {
 
     # Confirm unless --force
     if [[ "$force" != "true" ]]; then
-        echo -e "${YELLOW}This will delete ALL sessions for '$alias' and create a fresh one.${NC}"
+        echo -e "${YELLOW}This will kill ALL tmux sessions for '$alias' and create a fresh one.${NC}"
         read -p "Continue? [y/N] " confirm
         if [[ "$confirm" != "y" && "$confirm" != "Y" ]]; then
             echo -e "${BLUE}Cancelled.${NC}"
@@ -1019,23 +1044,23 @@ connect_hard_reset() {
         fi
     fi
 
-    # Skip session query — just force-delete and create fresh
-    # This ensures Hard Reset works even when the server is slow or sessions are stale
+    # Skip session query — just force-kill and create fresh
     echo -e "${GREEN}Hard Reset: $alias ($description)${NC}"
-    echo -e "${YELLOW}Deleting session '${alias}' and creating fresh...${NC}"
+    echo -e "${YELLOW}Killing tmux sessions and creating fresh...${NC}"
     echo ""
 
-    # Force-delete primary session and any parallel sessions, then create fresh
-    local safe_alias_remote
+    # Kill all matching tmux sessions, then create fresh
+    local safe_alias_remote safe_alias_tmux
     safe_alias_remote=$(regex_escape "$alias")
-    local remote_cmd="for s in \$(zellij list-sessions 2>/dev/null | sed 's/\x1b\[[0-9;]*m//g' | grep -oE '^${safe_alias_remote}(_[0-9]+)?' || true); do zellij delete-session \"\$s\" --force 2>/dev/null; done; ${cd_cmd}zellij attach -c ${alias}"
+    safe_alias_tmux=$(sanitize_session_name "$alias")
+    local remote_cmd="for s in \$(tmux list-sessions -F '#{session_name}' 2>/dev/null | grep -E '^${safe_alias_remote}(_[0-9]+)?\$' || true); do tmux kill-session -t \"\$s\" 2>/dev/null; done; ${cd_cmd}tmux new-session -A -s '${safe_alias_tmux}'"
     set_terminal_title "$(build_connection_title "$user" "$host" "$description")"
     "${ssh_cmd[@]}" -t "$remote_cmd"
     reset_terminal
     exit_or_return 0 "$stay_interactive"; return 0
 }
 
-# Connect to a connection (smart routing based on session count)
+# Connect to a connection via tmux (smart routing based on session count)
 connect() {
     local alias="$1"
     local auth_mode="${2:-}"  # Optional: "auth" for port forwarding mode
@@ -1062,7 +1087,7 @@ connect() {
     local cd_cmd
     cd_cmd=$(build_cd_cmd "$directory")
 
-    # Cleanup dead sessions first
+    # tmux auto-cleans dead sessions, but still count active ones
     echo -e "${YELLOW}Checking sessions...${NC}"
     cleanup_dead_sessions "$alias" "${ssh_cmd[@]}"
 
@@ -1072,7 +1097,7 @@ connect() {
 
     if [[ $session_count -gt 1 ]]; then
         # Multiple sessions exist -> go to session submenu
-        echo -e "${BLUE}Found $session_count sessions for $alias${NC}"
+        echo -e "${BLUE}Found $session_count tmux sessions for $alias${NC}"
         list_and_connect "$alias" "$auth_mode"
         return $?
     fi
@@ -1094,8 +1119,10 @@ connect() {
         final_ssh_cmd=("${SSH_CMD[@]}")
     fi
 
-    # Build remote command
-    local remote_cmd="${ZELLIJ_MOUSE_FIX}${cd_cmd}zellij attach -c ${session_name}"
+    # Build remote command: tmux new-session -A attaches if exists, creates if not
+    local safe_name
+    safe_name=$(sanitize_session_name "$session_name")
+    local remote_cmd="command -v tmux >/dev/null 2>&1 || { echo 'Error: tmux is not installed on this server. Install with: sudo apt install tmux'; exit 1; }; ${cd_cmd}tmux new-session -A -s '${safe_name}'"
 
     echo -e "${GREEN}Connecting to: $alias ($description)${NC}"
     echo -e "${BLUE}Host: ${user}@${host}:${port}${NC}"
@@ -1105,7 +1132,7 @@ connect() {
     if [[ -n "$directory" ]]; then
         echo -e "${BLUE}Directory: $directory${NC}"
     fi
-    echo -e "${BLUE}Session: zellij ${session_name}${NC}"
+    echo -e "${BLUE}Session: tmux ${session_name}${NC}"
     echo ""
 
     # Set terminal window title to user@host - description
@@ -1123,7 +1150,7 @@ connect_auth() {
     connect "$alias" "auth"
 }
 
-# Create a new parallel session (e.g., alias_2, alias_3, ...)
+# Create a new parallel tmux session (e.g., alias_2, alias_3, ...)
 connect_parallel() {
     local alias="$1"
     local auth_mode="${2:-}"
@@ -1156,7 +1183,9 @@ connect_parallel() {
     session_name=$(get_next_session_name "$alias" "${ssh_cmd[@]}")
 
     # Build remote command
-    local remote_cmd="${ZELLIJ_MOUSE_FIX}${cd_cmd}zellij attach -c ${session_name}"
+    local safe_name
+    safe_name=$(sanitize_session_name "$session_name")
+    local remote_cmd="command -v tmux >/dev/null 2>&1 || { echo 'Error: tmux is not installed on this server. Install with: sudo apt install tmux'; exit 1; }; ${cd_cmd}tmux new-session -A -s '${safe_name}'"
 
     echo -e "${GREEN}Creating parallel session: $alias ($description)${NC}"
     echo -e "${BLUE}Host: ${user}@${host}:${port}${NC}"
@@ -1166,13 +1195,57 @@ connect_parallel() {
     if [[ -n "$directory" ]]; then
         echo -e "${BLUE}Directory: $directory${NC}"
     fi
-    echo -e "${BLUE}Session: zellij ${session_name}${NC}"
+    echo -e "${BLUE}Session: tmux ${session_name}${NC}"
     echo ""
 
     # Set terminal window title to user@host - description
     set_terminal_title "$(build_connection_title "$user" "$host" "$description")"
 
     # Execute SSH
+    run_ssh "$remote_cmd" "$user" "$host" "$port" "${ssh_cmd[@]}"
+    reset_terminal
+}
+
+# Connect via Zellij (legacy fallback, triggered by Z key)
+connect_zellij() {
+    local alias="$1"
+    local stay_interactive=0
+    [[ "${INTERACTIVE_MODE:-0}" -eq 1 ]] && stay_interactive=1
+
+    # Parse connection
+    if ! parse_connection "$alias"; then
+        echo -e "${RED}Error: Connection '$alias' not found${NC}"
+        exit_or_return 1 "$stay_interactive"; return 1
+    fi
+    local host="$CONN_HOST" port="$CONN_PORT" user="$CONN_USER"
+    local directory="$CONN_DIR" description="$CONN_DESC" key="$CONN_KEY"
+
+    # Validate port
+    if ! validate_port "$port" "$alias"; then
+        exit_or_return 1 "$stay_interactive"; return 1
+    fi
+
+    # Build SSH command array
+    build_ssh_cmd "$host" "$port" "$user" "$key"
+    local ssh_cmd=("${SSH_CMD[@]}")
+
+    local cd_cmd
+    cd_cmd=$(build_cd_cmd "$directory")
+
+    local safe_alias_z
+    safe_alias_z=$(sanitize_session_name "$alias")
+    local remote_cmd="command -v zellij >/dev/null 2>&1 || { echo 'Error: zellij is not installed on this server.'; exit 1; }; ${cd_cmd}zellij attach -c '${safe_alias_z}'"
+
+    echo -e "${GREEN}Connecting to: $alias ($description) [Zellij]${NC}"
+    echo -e "${BLUE}Host: ${user}@${host}:${port}${NC}"
+    if [[ -n "$directory" ]]; then
+        echo -e "${BLUE}Directory: $directory${NC}"
+    fi
+    echo -e "${BLUE}Session: zellij ${alias}${NC}"
+    echo ""
+
+    set_terminal_title "$(build_connection_title "$user" "$host" "$description")"
+
     run_ssh "$remote_cmd" "$user" "$host" "$port" "${ssh_cmd[@]}"
     reset_terminal
 }
@@ -1442,15 +1515,15 @@ generate_completions() {
     case "$shell" in
         bash)
             cat <<'COMPEOF'
-# SM bash completions - source this or add to ~/.bashrc
-_sm_completions() {
+# SM2 bash completions - source this or add to ~/.bashrc
+_sm2_completions() {
     local cur prev commands
     cur="${COMP_WORDS[COMP_CWORD]}"
     prev="${COMP_WORDS[COMP_CWORD-1]}"
     commands="list set edit test validate doctor auth parallel reset sessions add remove completions"
 
     case "$prev" in
-        sm)
+        sm2)
             COMPREPLY=($(compgen -W "$commands --help --version --no-color" -- "$cur"))
             return
             ;;
@@ -1466,13 +1539,13 @@ _sm_completions() {
             ;;
     esac
 }
-complete -F _sm_completions sm
+complete -F _sm2_completions sm2
 COMPEOF
             ;;
         zsh)
             cat <<'COMPEOF'
-# SM zsh completions - source this or add to ~/.zshrc
-_sm() {
+# SM2 zsh completions - source this or add to ~/.zshrc
+_sm2() {
     local commands aliases
     commands=(list set edit test validate doctor auth parallel reset sessions add remove completions --help --version --no-color)
     aliases=(${(f)"$(awk -F'|' '!/^(#|$|default=|hostalias:)/ {print $1}' ~/.config/sm/connections.conf 2>/dev/null)"})
@@ -1491,7 +1564,7 @@ _sm() {
         esac
     fi
 }
-compdef _sm sm
+compdef _sm2 sm2
 COMPEOF
             ;;
         *)
@@ -1512,7 +1585,7 @@ main() {
                 exit 0
                 ;;
             --version|-v)
-                echo "sm $SM_VERSION"
+                echo "sm2 $SM_VERSION"
                 exit 0
                 ;;
             --no-color)
@@ -1533,33 +1606,33 @@ main() {
 
     init_config
 
-    # Get script name (for smd, sml detection)
+    # Get script name (for sm2d, sm2l detection)
     local script_name=$(basename "$0")
 
     # Handle different invocations
     case "$script_name" in
-        smd|sm1d)
-            # smd/sm1d = connect to default (quick access)
+        smd|sm2d)
+            # smd/sm2d = connect to default (quick access)
             local default_conn=$(get_default)
             if [[ -n "$default_conn" ]]; then
                 connect "$default_conn"
             else
-                echo -e "${RED}No default connection set. Use 'sm1 set <alias>' to set one.${NC}"
+                echo -e "${RED}No default connection set. Use 'sm set <alias>' to set one.${NC}"
                 exit 1
             fi
             ;;
-        sml|sm1l)
-            # sml/sm1l = list zellij sessions on default server
+        sml|sm2l)
+            # sml/sm2l = list tmux sessions on default server
             local default_conn=$(get_default)
             if [[ -n "$default_conn" ]]; then
                 list_and_connect "$default_conn"
             else
-                echo -e "${RED}No default connection set. Use 'sm1 set <alias>' to set one.${NC}"
+                echo -e "${RED}No default connection set. Use 'sm set <alias>' to set one.${NC}"
                 exit 1
             fi
             ;;
-        sm|sm1)
-            # sm with arguments
+        sm|sm2)
+            # sm2 with arguments
             if [[ $# -eq 0 ]]; then
                 # No args = interactive selection
                 interactive_select
@@ -1567,7 +1640,7 @@ main() {
                 list_connections
             elif [[ "$1" == "set" ]]; then
                 if [[ $# -lt 2 ]]; then
-                    echo -e "${RED}Usage: sm set <alias>${NC}"
+                    echo -e "${RED}Usage: sm2 set <alias>${NC}"
                     exit 1
                 fi
                 set_default "$2"
@@ -1575,7 +1648,7 @@ main() {
                 "${EDITOR:-vi}" "$CONFIG_FILE"
             elif [[ "$1" == "test" ]]; then
                 if [[ $# -lt 2 ]]; then
-                    echo -e "${RED}Usage: sm test <alias>${NC}"
+                    echo -e "${RED}Usage: sm2 test <alias>${NC}"
                     exit 1
                 fi
                 test_connection "$2"
@@ -1583,19 +1656,19 @@ main() {
                 validate_config
             elif [[ "$1" == "auth" ]]; then
                 if [[ $# -lt 2 ]]; then
-                    echo -e "${RED}Usage: sm auth <alias>${NC}"
+                    echo -e "${RED}Usage: sm2 auth <alias>${NC}"
                     exit 1
                 fi
                 connect_auth "$2"
             elif [[ "$1" == "parallel" ]]; then
                 if [[ $# -lt 2 ]]; then
-                    echo -e "${RED}Usage: sm parallel <alias>${NC}"
+                    echo -e "${RED}Usage: sm2 parallel <alias>${NC}"
                     exit 1
                 fi
                 connect_parallel "$2"
             elif [[ "$1" == "reset" ]]; then
                 if [[ $# -lt 2 ]]; then
-                    echo -e "${RED}Usage: sm reset <alias> [--force]${NC}"
+                    echo -e "${RED}Usage: sm2 reset <alias> [--force]${NC}"
                     exit 1
                 fi
                 local reset_alias="$2"
@@ -1603,7 +1676,7 @@ main() {
                 connect_hard_reset "$reset_alias" "$@"
             elif [[ "$1" == "sessions" ]]; then
                 if [[ $# -lt 2 ]]; then
-                    echo -e "${RED}Usage: sm sessions <alias>${NC}"
+                    echo -e "${RED}Usage: sm2 sessions <alias>${NC}"
                     exit 1
                 fi
                 list_and_connect "$2"
@@ -1611,7 +1684,7 @@ main() {
                 add_connection
             elif [[ "$1" == "remove" || "$1" == "rm" ]]; then
                 if [[ $# -lt 2 ]]; then
-                    echo -e "${RED}Usage: sm remove <alias>${NC}"
+                    echo -e "${RED}Usage: sm2 remove <alias>${NC}"
                     exit 1
                 fi
                 remove_connection "$2"

--- a/sm2
+++ b/sm2
@@ -375,6 +375,7 @@ interactive_select() {
             break
         fi
     done
+    local default_selected=$selected
 
     # Hide cursor and setup cleanup
     cleanup() {
@@ -536,7 +537,7 @@ interactive_select() {
                     tput cnorm
                     connect "${aliases[$real_idx]}"
                     rebuild_filter
-                    selected=0
+                    selected=$default_selected
                     redraw_menu
                 fi
             elif [[ "$key" == $'\x7f' || "$key" == $'\x08' ]]; then
@@ -606,7 +607,7 @@ interactive_select() {
                 connect "${aliases[$real_idx]}"
                 filter_text=""
                 rebuild_filter
-                selected=0
+                selected=$default_selected
                 redraw_menu
             fi
         elif [[ "$key" == 't' || "$key" == 'T' ]]; then
@@ -618,7 +619,7 @@ interactive_select() {
                 connect "${aliases[$real_idx]}"
                 filter_text=""
                 rebuild_filter
-                selected=0
+                selected=$default_selected
                 redraw_menu
             fi
         elif [[ "$key" == 'z' || "$key" == 'Z' ]]; then
@@ -630,7 +631,7 @@ interactive_select() {
                 connect_zellij "${aliases[$real_idx]}"
                 filter_text=""
                 rebuild_filter
-                selected=0
+                selected=$default_selected
                 redraw_menu
             fi
         elif [[ "$key" == 'a' || "$key" == 'A' ]]; then
@@ -641,7 +642,7 @@ interactive_select() {
                 connect_auth "${aliases[$real_idx]}"
                 filter_text=""
                 rebuild_filter
-                selected=0
+                selected=$default_selected
                 redraw_menu
             fi
         elif [[ "$key" == 'p' || "$key" == 'P' ]]; then
@@ -652,7 +653,7 @@ interactive_select() {
                 connect_parallel "${aliases[$real_idx]}"
                 filter_text=""
                 rebuild_filter
-                selected=0
+                selected=$default_selected
                 redraw_menu
             fi
         elif [[ "$key" == 'h' || "$key" == 'H' ]]; then
@@ -663,7 +664,7 @@ interactive_select() {
                 connect_hard_reset "${aliases[$real_idx]}" --force
                 filter_text=""
                 rebuild_filter
-                selected=0
+                selected=$default_selected
                 redraw_menu
             fi
         elif [[ "$key" == 'l' || "$key" == 'L' ]]; then
@@ -674,7 +675,7 @@ interactive_select() {
                 list_and_connect "${aliases[$real_idx]}"
                 filter_text=""
                 rebuild_filter
-                selected=0
+                selected=$default_selected
                 redraw_menu
             fi
         elif [[ "$key" == 'd' || "$key" == 'D' ]]; then
@@ -1086,7 +1087,7 @@ connect() {
     local sessions
     sessions=$(get_sessions_for_alias "$alias" "${ssh_cmd[@]}")
     local session_count
-    session_count=$(echo "$sessions" | grep -c . || echo "0")
+    session_count=$(printf '%s' "$sessions" | grep -c . || true)
 
     if [[ $session_count -gt 1 ]]; then
         # Multiple sessions exist -> go to session submenu

--- a/test_sm2.sh
+++ b/test_sm2.sh
@@ -1,0 +1,469 @@
+#!/usr/bin/env bash
+# test_sm2.sh - Automated test suite for sm2 helper functions
+# Run: bash test_sm2.sh
+
+set -uo pipefail
+
+# === Test Infrastructure ===
+
+PASS_COUNT=0
+FAIL_COUNT=0
+TOTAL_COUNT=0
+CURRENT_GROUP=""
+
+# Temp files for test config
+TEST_DIR=""
+TEST_CONFIG=""
+SM2_SOURCE=""
+
+setup() {
+    TEST_DIR=$(mktemp -d)
+    TEST_CONFIG="${TEST_DIR}/connections.conf"
+    SM2_SOURCE="${TEST_DIR}/sm2_functions.sh"
+
+    # Create test config with known data
+    cat > "$TEST_CONFIG" << 'TESTCONF'
+# SM test config
+# group: Production
+hostalias:prod.example.com=prod-srv
+hostalias:staging.example.com=staging-srv
+srv01|prod.example.com|22|deploy|/var/www|Production Server|~/.ssh/id_rsa
+srv02|prod.example.com|2222|admin|/home/admin|Admin Access|
+# group: Staging
+srv03|staging.example.com|22|dev|/opt/app|Staging App|~/.ssh/staging_key
+nodir|staging.example.com|22|user||No Directory|
+default=srv01
+TESTCONF
+
+    # Create sourceable copy of sm2 with main() call removed
+    local sm2_path
+    sm2_path="$(dirname "${BASH_SOURCE[0]}")/sm2"
+    if [[ ! -f "$sm2_path" ]]; then
+        echo "FATAL: sm2 not found at $sm2_path"
+        exit 2
+    fi
+    # Remove the final main "$@" invocation so we can source without executing
+    sed 's/^main "\$@"$/# main "$@" # disabled for testing/' "$sm2_path" > "$SM2_SOURCE"
+
+    # Source sm2 functions (override CONFIG_FILE to use test config)
+    # Suppress any git version detection output
+    (
+        source "$SM2_SOURCE"
+    ) 2>/dev/null || true
+
+    # Now source for real in current shell
+    CONFIG_FILE="$TEST_CONFIG"
+    source "$SM2_SOURCE"
+    CONFIG_FILE="$TEST_CONFIG"
+}
+
+teardown() {
+    if [[ -n "$TEST_DIR" && -d "$TEST_DIR" ]]; then
+        rm -rf "$TEST_DIR"
+    fi
+}
+
+# Assertion helpers
+assert_eq() {
+    local actual="$1"
+    local expected="$2"
+    local description="$3"
+    TOTAL_COUNT=$((TOTAL_COUNT + 1))
+    if [[ "$actual" == "$expected" ]]; then
+        PASS_COUNT=$((PASS_COUNT + 1))
+        printf "  PASS: %s\n" "$description"
+    else
+        FAIL_COUNT=$((FAIL_COUNT + 1))
+        printf "  FAIL: %s\n" "$description"
+        printf "    expected: '%s'\n" "$expected"
+        printf "    actual:   '%s'\n" "$actual"
+    fi
+}
+
+assert_neq() {
+    local actual="$1"
+    local unexpected="$2"
+    local description="$3"
+    TOTAL_COUNT=$((TOTAL_COUNT + 1))
+    if [[ "$actual" != "$unexpected" ]]; then
+        PASS_COUNT=$((PASS_COUNT + 1))
+        printf "  PASS: %s\n" "$description"
+    else
+        FAIL_COUNT=$((FAIL_COUNT + 1))
+        printf "  FAIL: %s\n" "$description"
+        printf "    should NOT be: '%s'\n" "$unexpected"
+    fi
+}
+
+assert_match() {
+    local actual="$1"
+    local pattern="$2"
+    local description="$3"
+    TOTAL_COUNT=$((TOTAL_COUNT + 1))
+    if [[ "$actual" =~ $pattern ]]; then
+        PASS_COUNT=$((PASS_COUNT + 1))
+        printf "  PASS: %s\n" "$description"
+    else
+        FAIL_COUNT=$((FAIL_COUNT + 1))
+        printf "  FAIL: %s\n" "$description"
+        printf "    value:   '%s'\n" "$actual"
+        printf "    pattern: '%s'\n" "$pattern"
+    fi
+}
+
+assert_exit_code() {
+    local expected="$1"
+    shift
+    local description="$1"
+    shift
+    TOTAL_COUNT=$((TOTAL_COUNT + 1))
+    # Run in subshell to avoid set +e leaking into the test suite
+    local actual
+    actual=$(set +e; "$@" >/dev/null 2>&1; echo $?)
+    if [[ $actual -eq $expected ]]; then
+        PASS_COUNT=$((PASS_COUNT + 1))
+        printf "  PASS: %s\n" "$description"
+    else
+        FAIL_COUNT=$((FAIL_COUNT + 1))
+        printf "  FAIL: %s\n" "$description"
+        printf "    expected exit: %d\n" "$expected"
+        printf "    actual exit:   %d\n" "$actual"
+    fi
+}
+
+group() {
+    CURRENT_GROUP="$1"
+    echo ""
+    echo "=== $1 ==="
+}
+
+# === Test Groups ===
+
+test_sanitize_session_name() {
+    group "sanitize_session_name()"
+
+    assert_eq "$(sanitize_session_name "myserver")" "myserver" \
+        "alphanumeric passes unchanged"
+
+    assert_eq "$(sanitize_session_name "my-server_01.prod")" "my-server_01.prod" \
+        "dashes, underscores, dots preserved"
+
+    assert_eq "$(sanitize_session_name 'rm -rf /; echo $(whoami)')" "rm-rfechowhoami" \
+        "strips spaces, semicolons, slashes, parens, dollar"
+
+    assert_eq "$(sanitize_session_name "hello\`world\`")" "helloworld" \
+        "strips backticks"
+
+    assert_eq "$(sanitize_session_name "")" "" \
+        "empty string returns empty"
+}
+
+test_shell_escape_double() {
+    group "shell_escape_double()"
+
+    assert_eq "$(shell_escape_double 'hello')" "hello" \
+        "plain string unchanged"
+
+    assert_eq "$(shell_escape_double 'back\slash')" 'back\\slash' \
+        "escapes backslash"
+
+    assert_eq "$(shell_escape_double 'say "hi"')" 'say \"hi\"' \
+        "escapes double quotes"
+
+    assert_eq "$(shell_escape_double 'cost $5')" 'cost \$5' \
+        "escapes dollar sign"
+
+    assert_eq "$(shell_escape_double 'run `cmd`')" 'run \`cmd\`' \
+        "escapes backticks"
+
+    assert_eq "$(shell_escape_double 'a\b"c$d`e')" 'a\\b\"c\$d\`e' \
+        "escapes mixed special chars"
+}
+
+test_build_cd_cmd() {
+    group "build_cd_cmd()"
+
+    assert_eq "$(build_cd_cmd "")" "" \
+        "empty directory returns empty string"
+
+    assert_eq "$(build_cd_cmd "/var/www")" 'cd "/var/www" 2>/dev/null; ' \
+        "simple directory produces cd command"
+
+    assert_eq "$(build_cd_cmd "/my path/dir")" 'cd "/my path/dir" 2>/dev/null; ' \
+        "directory with spaces is quoted"
+
+    assert_eq "$(build_cd_cmd '/path/$HOME')" 'cd "/path/\$HOME" 2>/dev/null; ' \
+        "dollar sign in path is escaped"
+
+    assert_eq "$(build_cd_cmd '/path/with"quotes')" 'cd "/path/with\"quotes" 2>/dev/null; ' \
+        "double quotes in path are escaped"
+
+    assert_eq "$(build_cd_cmd '/path/back\slash')" 'cd "/path/back\\slash" 2>/dev/null; ' \
+        "backslash in path is escaped"
+}
+
+test_parse_connection() {
+    group "parse_connection()"
+
+    # Valid alias
+    parse_connection "srv01"
+    local rc=$?
+    assert_eq "$rc" "0" "valid alias returns 0"
+    assert_eq "$CONN_HOST" "prod.example.com" "parses host correctly"
+    assert_eq "$CONN_PORT" "22" "parses port correctly"
+    assert_eq "$CONN_USER" "deploy" "parses user correctly"
+    assert_eq "$CONN_DIR" "/var/www" "parses directory correctly"
+    assert_eq "$CONN_DESC" "Production Server" "parses description correctly"
+    assert_eq "$CONN_KEY" "~/.ssh/id_rsa" "parses SSH key correctly"
+
+    # Connection without SSH key
+    parse_connection "srv02"
+    assert_eq "$CONN_PORT" "2222" "parses non-standard port"
+    assert_eq "$CONN_KEY" "" "empty SSH key parsed as empty"
+
+    # Connection without directory
+    parse_connection "nodir"
+    assert_eq "$CONN_DIR" "" "empty directory parsed as empty"
+
+    # Invalid alias
+    assert_exit_code 1 "unknown alias returns 1" parse_connection "nonexistent"
+
+    # Verify globals are cleared on failed parse
+    # First set them via a valid parse, then try an invalid one
+    parse_connection "srv01"
+    parse_connection "nonexistent" || true
+    assert_eq "$CONN_HOST" "" "CONN_HOST cleared after failed parse"
+    assert_eq "$CONN_PORT" "" "CONN_PORT cleared after failed parse"
+    assert_eq "$CONN_USER" "" "CONN_USER cleared after failed parse"
+}
+
+test_validate_port() {
+    group "validate_port()"
+
+    assert_exit_code 0 "port 1 is valid" validate_port "1" "test"
+    assert_exit_code 0 "port 22 is valid" validate_port "22" "test"
+    assert_exit_code 0 "port 443 is valid" validate_port "443" "test"
+    assert_exit_code 0 "port 8080 is valid" validate_port "8080" "test"
+    assert_exit_code 0 "port 65535 is valid" validate_port "65535" "test"
+
+    assert_exit_code 1 "port 0 is invalid" validate_port "0" "test"
+    assert_exit_code 1 "port 65536 is invalid" validate_port "65536" "test"
+    assert_exit_code 1 "port 'abc' is invalid" validate_port "abc" "test"
+    assert_exit_code 1 "empty port is invalid" validate_port "" "test"
+    assert_exit_code 1 "port -1 is invalid" validate_port "-1" "test"
+}
+
+test_regex_escape() {
+    group "regex_escape()"
+
+    assert_eq "$(regex_escape "hello")" "hello" \
+        "plain string unchanged"
+
+    assert_eq "$(regex_escape "C02BPM-ROB")" "C02BPM-ROB" \
+        "alias with dash unchanged (dash not special outside charset)"
+
+    assert_eq "$(regex_escape "a.b*c+d")" 'a\.b\*c\+d' \
+        "escapes dot, star, plus"
+
+    assert_eq "$(regex_escape 'x(y)[z]{w}')" 'x\(y\)\[z\]\{w\}' \
+        "escapes parens, brackets, braces"
+
+    assert_eq "$(regex_escape 'a|b')" 'a\|b' \
+        "escapes pipe"
+
+    assert_eq "$(regex_escape 'a\b')" 'a\\b' \
+        "escapes backslash"
+
+    assert_eq "$(regex_escape '^start$')" '\^start\$' \
+        "escapes caret and dollar"
+
+    assert_eq "$(regex_escape 'x?y')" 'x\?y' \
+        "escapes question mark"
+
+    # Verify escaped string works in grep -E
+    local escaped
+    escaped=$(regex_escape "srv01")
+    local match
+    match=$(echo "srv01" | grep -cE "^${escaped}$" || echo "0")
+    assert_eq "$match" "1" "escaped alias matches in grep -E"
+}
+
+test_get_default() {
+    group "get_default()"
+
+    local result
+    result=$(get_default)
+    assert_eq "$result" "srv01" "returns correct default"
+
+    # Test with no default
+    local orig_config="$CONFIG_FILE"
+    local no_default_config="${TEST_DIR}/no_default.conf"
+    grep -v '^default=' "$TEST_CONFIG" > "$no_default_config"
+    CONFIG_FILE="$no_default_config"
+    result=$(get_default)
+    assert_eq "$result" "" "returns empty when no default set"
+    CONFIG_FILE="$orig_config"
+}
+
+test_get_host_alias() {
+    group "get_host_alias()"
+
+    local result
+    result=$(get_host_alias "prod.example.com")
+    assert_eq "$result" "prod-srv" "returns alias for known host"
+
+    result=$(get_host_alias "staging.example.com")
+    assert_eq "$result" "staging-srv" "returns alias for second known host"
+
+    result=$(get_host_alias "unknown.example.com")
+    assert_eq "$result" "" "returns empty for unknown host"
+}
+
+test_build_ssh_cmd() {
+    group "build_ssh_cmd()"
+
+    # Basic (no key, no auth)
+    build_ssh_cmd "host.example.com" "22" "user" ""
+    # SSH_CMD should be: ssh -R 52698:localhost:52698 -p 22 user@host.example.com
+    local cmd_str="${SSH_CMD[*]}"
+    assert_match "$cmd_str" "^ssh " "starts with ssh"
+    assert_match "$cmd_str" "-p 22 " "includes port 22 (anchored with trailing space)"
+    assert_match "$cmd_str" "user@host\.example\.com$" "ends with user@host"
+    assert_match "$cmd_str" "-R 52698:localhost:52698" "includes rmate port forward"
+
+    # With key
+    build_ssh_cmd "host.example.com" "22" "user" "/path/to/key"
+    cmd_str="${SSH_CMD[*]}"
+    assert_match "$cmd_str" "-i /path/to/key" "includes -i with key path"
+
+    # With auth mode
+    build_ssh_cmd "host.example.com" "22" "user" "" "auth"
+    cmd_str="${SSH_CMD[*]}"
+    assert_match "$cmd_str" "-L 1455:localhost:1455" "includes auth port forward"
+
+    # With key + auth
+    build_ssh_cmd "host.example.com" "2222" "admin" "/key" "auth"
+    cmd_str="${SSH_CMD[*]}"
+    assert_match "$cmd_str" "-i /key" "key present with auth mode"
+    assert_match "$cmd_str" "-L 1455:localhost:1455" "auth forward present with key"
+    assert_match "$cmd_str" "-p 2222 " "custom port 2222 (anchored with trailing space)"
+
+    # Verify port 22 does NOT match port 2222
+    build_ssh_cmd "host.example.com" "2222" "user" ""
+    cmd_str="${SSH_CMD[*]}"
+    local has_22_only=""
+    # Check individual array elements for exact port match
+    for elem in "${SSH_CMD[@]}"; do
+        [[ "$elem" == "22" ]] && has_22_only="found"
+    done
+    assert_eq "$has_22_only" "" "port 2222 does not have element '22'"
+}
+
+test_build_connection_title() {
+    group "build_connection_title()"
+
+    # With hostalias and description
+    local result
+    result=$(build_connection_title "deploy" "prod.example.com" "Production Server")
+    assert_eq "$result" "deploy@prod-srv - Production Server" \
+        "title with hostalias and description"
+
+    # Without description
+    result=$(build_connection_title "user" "prod.example.com" "")
+    assert_eq "$result" "user@prod-srv" \
+        "title without description"
+
+    # Without hostalias (unknown host)
+    result=$(build_connection_title "root" "unknown.host.com" "My Server")
+    assert_eq "$result" "root@unknown.host.com - My Server" \
+        "title falls back to hostname when no hostalias"
+}
+
+test_exit_or_return() {
+    group "exit_or_return()"
+
+    # With stay=1, should return (not exit)
+    local rc=0
+    exit_or_return 0 1 || rc=$?
+    assert_eq "$rc" "0" "stay=1 code=0 returns 0"
+
+    rc=0
+    exit_or_return 42 1 || rc=$?
+    assert_eq "$rc" "42" "stay=1 code=42 returns 42"
+
+    # With stay=0, should exit - test in subshell
+    rc=0
+    (exit_or_return 0 0) || rc=$?
+    assert_eq "$rc" "0" "stay=0 code=0 exits 0"
+
+    rc=0
+    (exit_or_return 7 0) || rc=$?
+    assert_eq "$rc" "7" "stay=0 code=7 exits 7"
+}
+
+test_calculate_column_widths() {
+    group "calculate_column_widths()"
+
+    calculate_column_widths
+
+    # Minimum widths (from the code: W_ALIAS=5, W_HOST=9, etc.)
+    # After processing, W_ALIAS gets +2 padding
+    # srv01 is 5 chars, so W_ALIAS should be max(5,5)+2 = 7
+    local min_alias=7
+    assert_match "$W_ALIAS" "^[0-9]+$" "W_ALIAS is numeric"
+    if [[ $W_ALIAS -ge $min_alias ]]; then
+        TOTAL_COUNT=$((TOTAL_COUNT + 1))
+        PASS_COUNT=$((PASS_COUNT + 1))
+        printf "  PASS: W_ALIAS >= %d (actual: %d)\n" "$min_alias" "$W_ALIAS"
+    else
+        TOTAL_COUNT=$((TOTAL_COUNT + 1))
+        FAIL_COUNT=$((FAIL_COUNT + 1))
+        printf "  FAIL: W_ALIAS >= %d (actual: %d)\n" "$min_alias" "$W_ALIAS"
+    fi
+
+    # W_DESC should accommodate "Production Server" (17 chars) + 2 padding = 19
+    local min_desc=19
+    if [[ $W_DESC -ge $min_desc ]]; then
+        TOTAL_COUNT=$((TOTAL_COUNT + 1))
+        PASS_COUNT=$((PASS_COUNT + 1))
+        printf "  PASS: W_DESC >= %d (actual: %d)\n" "$min_desc" "$W_DESC"
+    else
+        TOTAL_COUNT=$((TOTAL_COUNT + 1))
+        FAIL_COUNT=$((FAIL_COUNT + 1))
+        printf "  FAIL: W_DESC >= %d (actual: %d)\n" "$min_desc" "$W_DESC"
+    fi
+}
+
+# === Main ===
+
+run_all_tests() {
+    setup
+
+    test_sanitize_session_name
+    test_shell_escape_double
+    test_build_cd_cmd
+    test_parse_connection
+    test_validate_port
+    test_regex_escape
+    test_get_default
+    test_get_host_alias
+    test_build_ssh_cmd
+    test_build_connection_title
+    test_exit_or_return
+    test_calculate_column_widths
+
+    teardown
+
+    echo ""
+    echo "==============================="
+    echo "Results: ${PASS_COUNT} passed, ${FAIL_COUNT} failed, ${TOTAL_COUNT} total"
+    echo "==============================="
+
+    if [[ $FAIL_COUNT -gt 0 ]]; then
+        return 1
+    fi
+    return 0
+}
+
+run_all_tests
+exit $?

--- a/tests/test_interactive_select.sh
+++ b/tests/test_interactive_select.sh
@@ -1,0 +1,267 @@
+#!/usr/bin/env bash
+# Test suite for sm2 interactive_select() logic
+# Tests selection indexing and default connection behavior
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(dirname "$SCRIPT_DIR")"
+SM2="$REPO_DIR/sm2"
+PASS=0
+FAIL=0
+TOTAL=0
+
+# Create a temporary config for testing
+TEST_CONFIG=$(mktemp)
+trap 'rm -f "$TEST_CONFIG"' EXIT
+
+cat > "$TEST_CONFIG" <<'EOF'
+# Test config
+hostalias:host1.example.com=H1
+hostalias:host2.example.com=H2
+hostalias:host3.example.com=H3
+
+conn-A|host1.example.com|22|user1|/home/user1|Description A|
+conn-B|host1.example.com|22|user2|/home/user2|Description B|
+conn-C|host2.example.com|22|user3|/home/user3|Description C|
+conn-D|host2.example.com|22|user4|/home/user4|Description D|
+conn-E|host3.example.com|22|user5|/home/user5|Description E|
+
+default=conn-C
+EOF
+
+assert_eq() {
+    local test_name="$1"
+    local expected="$2"
+    local actual="$3"
+    TOTAL=$((TOTAL + 1))
+    if [[ "$expected" == "$actual" ]]; then
+        echo "  PASS: $test_name"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL: $test_name (expected='$expected', actual='$actual')"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# Helper functions extracted from sm2
+get_host_alias() {
+    local hostname="$1"
+    local alias_line
+    alias_line=$(awk -F'=' -v key="hostalias:${hostname}" '$1 == key {print substr($0, length($1)+2)}' "$TEST_CONFIG" 2>/dev/null || echo "")
+    if [[ -n "$alias_line" ]]; then
+        echo "$alias_line"
+    else
+        echo ""
+    fi
+}
+
+get_default() {
+    grep "^default=" "$TEST_CONFIG" 2>/dev/null | cut -d'=' -f2 | tr -d ' ' || echo ""
+}
+
+run_tests() {
+    echo "=== Test Suite: interactive_select logic ==="
+    echo ""
+
+    # Simulate the array building from interactive_select
+    local aliases=()
+    local hostaliases=()
+    local users=()
+    local directories=()
+    local descriptions=()
+
+    while IFS= read -r raw_line; do
+        local alias host port user directory description key
+        IFS='|' read -r alias host port user directory description key <<< "$raw_line"
+        [[ "$alias" =~ ^#.*$ ]] && continue
+        [[ -z "$alias" ]] && continue
+        [[ "$alias" =~ ^default= ]] && continue
+        [[ "$alias" =~ ^hostalias: ]] && continue
+        aliases+=("$alias")
+        hostaliases+=("$(get_host_alias "$host")")
+        users+=("$user")
+        directories+=("$directory")
+        descriptions+=("$description")
+    done < "$TEST_CONFIG"
+
+    echo "--- Test: Config parsing ---"
+    assert_eq "alias count" "5" "${#aliases[@]}"
+    assert_eq "alias[0]" "conn-A" "${aliases[0]}"
+    assert_eq "alias[1]" "conn-B" "${aliases[1]}"
+    assert_eq "alias[2]" "conn-C" "${aliases[2]}"
+    assert_eq "alias[3]" "conn-D" "${aliases[3]}"
+    assert_eq "alias[4]" "conn-E" "${aliases[4]}"
+
+    # Test default detection
+    local default_conn
+    default_conn=$(get_default)
+    assert_eq "default connection" "conn-C" "$default_conn"
+
+    # Test initial selection: should find index of default
+    local selected=0
+    local i
+    for i in "${!aliases[@]}"; do
+        if [[ "${aliases[$i]}" == "$default_conn" ]]; then
+            selected=$i
+            break
+        fi
+    done
+    assert_eq "selected index for default" "2" "$selected"
+
+    # Test filtered_indices (no filter = all)
+    local filtered_indices=()
+    for i in "${!aliases[@]}"; do
+        filtered_indices+=("$i")
+    done
+    assert_eq "filtered_indices count" "5" "${#filtered_indices[@]}"
+    assert_eq "filtered_indices[0]" "0" "${filtered_indices[0]}"
+    assert_eq "filtered_indices[2]" "2" "${filtered_indices[2]}"
+
+    # Test get_selected_real_index logic
+    local real_idx="${filtered_indices[$selected]}"
+    assert_eq "real index for default selection" "2" "$real_idx"
+    assert_eq "alias at real index" "conn-C" "${aliases[$real_idx]}"
+
+    echo ""
+    echo "--- Test: Arrow key navigation simulation ---"
+
+    # Simulate down arrow: selected goes from 2 to 3
+    local fi_count=${#filtered_indices[@]}
+    if [[ $selected -lt $((fi_count - 1)) ]]; then
+        selected=$((selected + 1))
+    else
+        selected=0
+    fi
+    assert_eq "after down arrow, selected" "3" "$selected"
+    real_idx="${filtered_indices[$selected]}"
+    assert_eq "after down arrow, real index" "3" "$real_idx"
+    assert_eq "after down arrow, alias" "conn-D" "${aliases[$real_idx]}"
+
+    # Simulate up arrow: selected goes from 3 to 2
+    if [[ $selected -gt 0 ]]; then
+        selected=$((selected - 1))
+    else
+        selected=$((fi_count - 1))
+    fi
+    assert_eq "after up arrow, selected" "2" "$selected"
+    real_idx="${filtered_indices[$selected]}"
+    assert_eq "after up arrow, alias" "conn-C" "${aliases[$real_idx]}"
+
+    # Simulate up arrow from 0 -> wraps to last
+    selected=0
+    if [[ $selected -gt 0 ]]; then
+        selected=$((selected - 1))
+    else
+        selected=$((fi_count - 1))
+    fi
+    assert_eq "up from 0, wraps to" "4" "$selected"
+    real_idx="${filtered_indices[$selected]}"
+    assert_eq "up from 0, alias" "conn-E" "${aliases[$real_idx]}"
+
+    # Simulate down arrow from last -> wraps to 0
+    selected=$((fi_count - 1))
+    if [[ $selected -lt $((fi_count - 1)) ]]; then
+        selected=$((selected + 1))
+    else
+        selected=0
+    fi
+    assert_eq "down from last, wraps to" "0" "$selected"
+    real_idx="${filtered_indices[$selected]}"
+    assert_eq "down from last, alias" "conn-A" "${aliases[$real_idx]}"
+
+    echo ""
+    echo "--- Test: Filter mode selection ---"
+
+    # Simulate filter that matches conn-C and conn-D (host2)
+    filtered_indices=()
+    for i in "${!aliases[@]}"; do
+        local haystack
+        haystack=$(printf '%s %s %s %s %s' "${aliases[$i]}" "${hostaliases[$i]}" "${users[$i]}" "${directories[$i]}" "${descriptions[$i]}" | tr '[:upper:]' '[:lower:]')
+        if [[ "$haystack" == *"h2"* ]]; then
+            filtered_indices+=("$i")
+        fi
+    done
+    assert_eq "filtered count for 'h2'" "2" "${#filtered_indices[@]}"
+    assert_eq "filtered[0] -> index" "2" "${filtered_indices[0]}"
+    assert_eq "filtered[1] -> index" "3" "${filtered_indices[1]}"
+
+    # After filter, selected resets to 0
+    selected=0
+    real_idx="${filtered_indices[$selected]}"
+    assert_eq "filter selected=0, alias" "conn-C" "${aliases[$real_idx]}"
+
+    # Down arrow in filter
+    fi_count=${#filtered_indices[@]}
+    if [[ $selected -lt $((fi_count - 1)) ]]; then
+        selected=$((selected + 1))
+    fi
+    real_idx="${filtered_indices[$selected]}"
+    assert_eq "filter after down, alias" "conn-D" "${aliases[$real_idx]}"
+
+    echo ""
+    echo "--- Test: Real config default behavior ---"
+    # Test with the actual config to reproduce the bug
+    local real_config="$HOME/.config/sm/connections.conf"
+    if [[ -f "$real_config" ]]; then
+        local real_aliases=()
+        while IFS= read -r raw_line; do
+            local alias host port user directory description key
+            IFS='|' read -r alias host port user directory description key <<< "$raw_line"
+            [[ "$alias" =~ ^#.*$ ]] && continue
+            [[ -z "$alias" ]] && continue
+            [[ "$alias" =~ ^default= ]] && continue
+            [[ "$alias" =~ ^hostalias: ]] && continue
+            real_aliases+=("$alias")
+        done < "$real_config"
+
+        local real_default
+        real_default=$(grep "^default=" "$real_config" 2>/dev/null | cut -d'=' -f2 | tr -d ' ' || echo "")
+
+        echo "  Real config: ${#real_aliases[@]} connections, default='$real_default'"
+
+        # Find default index
+        local default_idx=-1
+        for i in "${!real_aliases[@]}"; do
+            if [[ "${real_aliases[$i]}" == "$real_default" ]]; then
+                default_idx=$i
+                break
+            fi
+        done
+        assert_eq "default found in array" "true" "$( [[ $default_idx -ge 0 ]] && echo true || echo false )"
+
+        if [[ $default_idx -ge 0 ]]; then
+            echo "  Default '$real_default' is at index $default_idx"
+            assert_eq "alias at default index" "$real_default" "${real_aliases[$default_idx]}"
+
+            # Check what would happen if we had an off-by-one
+            if [[ $default_idx -gt 0 ]]; then
+                echo "  alias[$(( default_idx - 1 ))] = ${real_aliases[$(( default_idx - 1 ))]}"
+            fi
+            if [[ $default_idx -lt $(( ${#real_aliases[@]} - 1 )) ]]; then
+                echo "  alias[$(( default_idx + 1 ))] = ${real_aliases[$(( default_idx + 1 ))]}"
+            fi
+
+            # Simulate: selected=default_idx, filtered=[0..n-1]
+            local real_filtered=()
+            for i in "${!real_aliases[@]}"; do
+                real_filtered+=("$i")
+            done
+            selected=$default_idx
+            real_idx="${real_filtered[$selected]}"
+            assert_eq "real config: selected alias" "$real_default" "${real_aliases[$real_idx]}"
+
+            # Verify that index 0 is NOT C03BPM-ROB (that would mean off-by-one)
+            echo "  alias[0] = ${real_aliases[0]}"
+        fi
+    else
+        echo "  Skipping real config test (no config found)"
+    fi
+}
+
+run_tests
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed, $TOTAL total ==="
+if [[ $FAIL -gt 0 ]]; then
+    exit 1
+fi

--- a/tests/test_security.sh
+++ b/tests/test_security.sh
@@ -1,0 +1,254 @@
+#!/usr/bin/env bash
+# Security tests for sm2
+# Tests sanitization, escaping, validation, and config permissions
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SM2="$SCRIPT_DIR/../sm2"
+PASS=0
+FAIL=0
+
+pass() { PASS=$((PASS + 1)); echo "  PASS: $1"; }
+fail() { FAIL=$((FAIL + 1)); echo "  FAIL: $1"; }
+
+# Source sm2 functions without running main
+# We extract just the functions we need to test
+source_functions() {
+    # Extract helper functions by sourcing in a subshell with main overridden
+    eval "$(sed 's/^main "\$@"$//' "$SM2")"
+}
+
+# === Test sanitize_session_name ===
+echo "=== sanitize_session_name ==="
+
+test_sanitize() {
+    local input="$1" expected="$2" label="$3"
+    local result
+    result=$(printf '%s' "$input" | tr -cd 'A-Za-z0-9_.-')
+    if [[ "$result" == "$expected" ]]; then
+        pass "$label"
+    else
+        fail "$label (got '$result', expected '$expected')"
+    fi
+}
+
+test_sanitize "normal_name" "normal_name" "alphanumeric with underscore"
+test_sanitize "name-with.dots" "name-with.dots" "dashes and dots"
+test_sanitize "test'; rm -rf /" "testrm-rf" "single quote injection stripped"
+test_sanitize 'test"; rm -rf /' 'testrm-rf' "double quote injection stripped"
+test_sanitize "test\`whoami\`" "testwhoami" "backtick injection stripped"
+test_sanitize "name with spaces" "namewithspaces" "spaces stripped"
+test_sanitize "name;cmd" "namecmd" "semicolon stripped"
+test_sanitize $'name\nnewline' "namenewline" "newline stripped"
+test_sanitize "" "" "empty string stays empty"
+
+# === Test shell_escape_double ===
+echo ""
+echo "=== shell_escape_double ==="
+
+test_escape() {
+    local input="$1" expected="$2" label="$3"
+    local result
+    result=$(printf '%s' "$input" | sed 's/[\\\"$`!]/\\&/g')
+    if [[ "$result" == "$expected" ]]; then
+        pass "$label"
+    else
+        fail "$label (got '$result', expected '$expected')"
+    fi
+}
+
+test_escape 'hello' 'hello' "plain string unchanged"
+test_escape 'path/to/dir' 'path/to/dir' "slashes unchanged"
+test_escape 'has"quote' 'has\"quote' "double quote escaped"
+test_escape 'has$var' 'has\$var' "dollar sign escaped"
+test_escape 'has`cmd`' 'has\`cmd\`' "backticks escaped"
+test_escape 'has\back' 'has\\back' "backslash escaped"
+test_escape 'has!bang' 'has\!bang' "exclamation mark escaped"
+test_escape 'all"$`\!' 'all\"\$\`\\\!' "all special chars escaped"
+
+# === Test validate_port ===
+echo ""
+echo "=== validate_port ==="
+
+test_port_valid() {
+    local port="$1" label="$2"
+    if validate_port_check "$port"; then
+        pass "$label"
+    else
+        fail "$label"
+    fi
+}
+
+test_port_invalid() {
+    local port="$1" label="$2"
+    if ! validate_port_check "$port"; then
+        pass "$label"
+    else
+        fail "$label"
+    fi
+}
+
+# Inline port validation (same logic as sm2)
+validate_port_check() {
+    local port="$1"
+    [[ -n "$port" ]] && [[ "$port" =~ ^[0-9]+$ ]] && [[ "$port" -ge 1 ]] && [[ "$port" -le 65535 ]]
+}
+
+test_port_valid "22" "standard SSH port"
+test_port_valid "1" "minimum valid port"
+test_port_valid "65535" "maximum valid port"
+test_port_valid "8080" "common alternative port"
+test_port_invalid "" "empty port rejected"
+test_port_invalid "0" "port 0 rejected"
+test_port_invalid "65536" "port > 65535 rejected"
+test_port_invalid "-1" "negative port rejected"
+test_port_invalid "abc" "non-numeric rejected"
+test_port_invalid "22; rm -rf /" "injection in port rejected"
+test_port_invalid "22abc" "mixed alphanumeric rejected"
+
+# === Test regex_escape ===
+echo ""
+echo "=== regex_escape ==="
+
+test_regex_escape() {
+    local input="$1" label="$2"
+    local escaped
+    escaped=$(printf '%s' "$input" | sed 's/[][\\.^$*+?(){}|]/\\&/g')
+    # The escaped string should match the literal input in grep -E
+    if echo "$input" | grep -qE "^${escaped}$" 2>/dev/null; then
+        pass "$label"
+    else
+        fail "$label"
+    fi
+}
+
+test_regex_escape "simple" "plain string"
+test_regex_escape "test.name" "dot escaped"
+test_regex_escape "test*" "star escaped"
+test_regex_escape "test+plus" "plus escaped"
+test_regex_escape "test(paren)" "parens escaped"
+test_regex_escape "test[bracket]" "brackets escaped"
+test_regex_escape "test{brace}" "braces escaped"
+test_regex_escape "test^caret" "caret escaped"
+test_regex_escape 'test$dollar' "dollar escaped"
+test_regex_escape "test|pipe" "pipe escaped"
+test_regex_escape "test?question" "question escaped"
+
+# === Test alias validation (add_connection rules) ===
+echo ""
+echo "=== alias validation ==="
+
+test_alias_valid() {
+    local alias="$1" label="$2"
+    if [[ -n "$alias" ]] && [[ "$alias" =~ ^[A-Za-z0-9_.-]+$ ]]; then
+        pass "$label"
+    else
+        fail "$label"
+    fi
+}
+
+test_alias_invalid() {
+    local alias="$1" label="$2"
+    if [[ -z "$alias" ]] || [[ ! "$alias" =~ ^[A-Za-z0-9_.-]+$ ]]; then
+        pass "$label"
+    else
+        fail "$label"
+    fi
+}
+
+test_alias_valid "myserver" "simple alias"
+test_alias_valid "my-server" "alias with dash"
+test_alias_valid "my_server" "alias with underscore"
+test_alias_valid "my.server" "alias with dot"
+test_alias_valid "sm231" "alias with numbers"
+test_alias_invalid "" "empty alias rejected"
+test_alias_invalid "my server" "alias with space rejected"
+test_alias_invalid "my|server" "alias with pipe rejected"
+test_alias_invalid "my;server" "alias with semicolon rejected"
+test_alias_invalid 'my"server' "alias with quote rejected"
+test_alias_invalid "my\`server" "alias with backtick rejected"
+test_alias_invalid $'my\nserver' "alias with newline rejected"
+test_alias_invalid "my/server" "alias with slash rejected"
+
+# === Test host/user validation ===
+echo ""
+echo "=== host/user validation ==="
+
+test_hostuser_valid() {
+    local val="$1" label="$2"
+    if [[ ! "$val" =~ [[:space:]\;\`\$\(\)\{\}\|\'\"\\] ]]; then
+        pass "$label"
+    else
+        fail "$label"
+    fi
+}
+
+test_hostuser_invalid() {
+    local val="$1" label="$2"
+    if [[ "$val" =~ [[:space:]\;\`\$\(\)\{\}\|\'\"\\] ]]; then
+        pass "$label"
+    else
+        fail "$label"
+    fi
+}
+
+test_hostuser_valid "example.com" "normal hostname"
+test_hostuser_valid "192.168.1.1" "IP address"
+test_hostuser_valid "user-name" "user with dash"
+test_hostuser_valid "rob_admin" "user with underscore"
+test_hostuser_invalid "host;cmd" "semicolon injection rejected"
+test_hostuser_invalid 'host`cmd`' "backtick injection rejected"
+test_hostuser_invalid 'host$(cmd)' "dollar-paren injection rejected"
+test_hostuser_invalid "host name" "space in host rejected"
+test_hostuser_invalid "host'name" "single quote rejected"
+test_hostuser_invalid 'host"name' "double quote rejected"
+test_hostuser_invalid 'host\name' "backslash rejected"
+test_hostuser_invalid 'host|name' "pipe rejected"
+
+# === Test config file permissions ===
+echo ""
+echo "=== config file permissions ==="
+
+test_config_permissions() {
+    local tmpdir
+    tmpdir=$(mktemp -d)
+    local config_dir="$tmpdir/.config/sm"
+    local config_file="$config_dir/connections.conf"
+
+    # Simulate init_config logic
+    mkdir -p "$config_dir"
+    chmod 700 "$config_dir"
+    touch "$config_file"
+    chmod 600 "$config_file"
+
+    local dir_perms file_perms
+    dir_perms=$(stat -c '%a' "$config_dir")
+    file_perms=$(stat -c '%a' "$config_file")
+
+    if [[ "$dir_perms" == "700" ]]; then
+        pass "config dir permissions 700"
+    else
+        fail "config dir permissions (got $dir_perms, expected 700)"
+    fi
+
+    if [[ "$file_perms" == "600" ]]; then
+        pass "config file permissions 600"
+    else
+        fail "config file permissions (got $file_perms, expected 600)"
+    fi
+
+    rm -rf "$tmpdir"
+}
+
+test_config_permissions
+
+# === Summary ===
+echo ""
+echo "================================"
+echo "Results: $PASS passed, $FAIL failed"
+echo "================================"
+
+if [[ $FAIL -gt 0 ]]; then
+    exit 1
+fi

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -45,7 +45,7 @@ done
 
 # --- Install locations and binaries ---
 INSTALL_DIRS=("$HOME/.local/bin" "/usr/local/bin")
-BINARIES=("sm" "smd" "sml")
+BINARIES=("sm" "smd" "sml" "sm1" "sm1d" "sm1l" "sm2" "sm2d" "sm2l")
 CONFIG_DIR="$HOME/.config/sm"
 
 # --- Build list of files that actually exist (scan both locations) ---

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# SM - SSH Manager Uninstaller
+
+set -euo pipefail
+
+# --- Defaults ---
+YES=false
+PURGE=false
+
+# --- Usage ---
+usage() {
+    cat <<'EOF'
+Usage: uninstall.sh [OPTIONS]
+
+Remove SM (SSH Manager) binaries.
+
+Options:
+  --yes     Skip confirmation prompt (for scripting/CI)
+  --purge   Also remove config directory (~/.config/sm/)
+  --help    Show this help message
+
+Examples:
+  ./uninstall.sh                # Interactive uninstall
+  ./uninstall.sh --yes          # Non-interactive uninstall
+  ./uninstall.sh --purge        # Also remove config
+  ./uninstall.sh --yes --purge  # CI: remove everything
+EOF
+    exit 0
+}
+
+# --- Parse flags ---
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --help)  usage ;;
+        --yes)   YES=true ;;
+        --purge) PURGE=true ;;
+        *)
+            echo "Error: Unknown option '$1'" >&2
+            echo "Run './uninstall.sh --help' for usage." >&2
+            exit 1
+            ;;
+    esac
+    shift
+done
+
+# --- Install locations and binaries ---
+INSTALL_DIRS=("$HOME/.local/bin" "/usr/local/bin")
+BINARIES=("sm" "smd" "sml")
+CONFIG_DIR="$HOME/.config/sm"
+
+# --- Build list of files that actually exist (scan both locations) ---
+targets=()
+for dir in "${INSTALL_DIRS[@]}"; do
+    for bin in "${BINARIES[@]}"; do
+        [[ -f "$dir/$bin" ]] && targets+=("$dir/$bin")
+    done
+done
+if $PURGE && [[ -d "$CONFIG_DIR" ]]; then
+    targets+=("$CONFIG_DIR/")
+fi
+
+# --- Nothing to remove? ---
+if [[ ${#targets[@]} -eq 0 ]]; then
+    echo "Nothing to remove. SM is not installed."
+    exit 0
+fi
+
+# --- Show what will be removed ---
+echo "The following will be removed:"
+for t in "${targets[@]}"; do
+    echo "  $t"
+done
+# --- Warn about sudo + --purge targeting user config ---
+if $PURGE && [[ $EUID -eq 0 ]] && [[ -d "$CONFIG_DIR" ]]; then
+    echo "Warning: --purge will remove config for user: $(logname 2>/dev/null || echo unknown)"
+    echo "  $CONFIG_DIR"
+    echo ""
+fi
+
+# --- Confirmation ---
+if ! $YES; then
+    if [[ ! -t 0 ]]; then
+        echo "Error: No TTY detected. Use --yes for non-interactive uninstall." >&2
+        exit 1
+    fi
+    read -rp "Proceed? [y/N] " answer
+    if [[ "$answer" != [yY] ]]; then
+        echo "Aborted."
+        exit 0
+    fi
+fi
+
+# --- Remove binaries ---
+removed=()
+for dir in "${INSTALL_DIRS[@]}"; do
+    for bin in "${BINARIES[@]}"; do
+        if [[ -f "$dir/$bin" ]]; then
+            rm -f "$dir/$bin"
+            removed+=("$dir/$bin")
+        fi
+    done
+done
+
+# --- Remove config if --purge ---
+if $PURGE && [[ -d "$CONFIG_DIR" ]]; then
+    rm -rf "$CONFIG_DIR"
+    removed+=("$CONFIG_DIR/")
+fi
+
+# --- Report ---
+echo ""
+echo "Removed:"
+for r in "${removed[@]}"; do
+    echo "  $r"
+done
+
+if ! $PURGE && [[ -d "$CONFIG_DIR" ]]; then
+    echo ""
+    echo "Configuration remains at $CONFIG_DIR"
+    echo "To remove config: ./uninstall.sh --purge"
+fi


### PR DESCRIPTION
## Summary

Full refactoring of SM (SSH Manager) addressing 28 of 31 open issues across P0-P3 priorities. Executed via coordinated agent team with Codex review at every gate.

### Phase A: Security Hardening (P0) — Issues #5, #6, #7, #8, #9, #35
- **#5**: Convert all SSH commands from string concatenation to bash arrays
- **#6**: Quote `$directory` in `cd_cmd` at all 4 locations
- **#7**: Replace regex-vulnerable grep patterns with `awk` exact matching for config lookups, `regex_escape()` + `grep -E` for session patterns
- **#8**: Add `validate_port()` with range check (1-65535) in all connection functions
- **#9**: Add `--help`, `--yes`, `--purge` flags and confirmation prompt to `uninstall.sh`
- **#35**: Add `.gitignore` covering env, editor, IDE, OS, credential files

### Phase B: DRY Refactoring (P1) — Issues #10, #11, #12, #13, #14, #15
- **#10**: Extract `build_ssh_cmd()` helper (replaces 5 duplications)
- **#11**: Extract `parse_connection()` helper (replaces 4 duplications)
- **#12**: Extract `exit_or_return()` helper (replaces 14 duplications)
- **#13**: Extract `build_cd_cmd()` helper (replaces 4 duplications)
- **#14**: Reduce monster functions via helper usage
- **#15**: Extract `calculate_column_widths()` (replaces 2 duplications)

### Phase C: Features (P2/P3) — Issues #16-#25, #27, #30-#34
- **#16**: `--help`/`-h` and `--version`/`-v` flags
- **#17**: `sm test <alias>` SSH connectivity testing
- **#18**: CLI equivalents: `sm auth`, `sm parallel`, `sm reset`, `sm sessions`
- **#19**: Search/filter in interactive menu (`/` to search)
- **#20**: Description column in connection list
- **#21**: `sm edit` command (opens config in $EDITOR)
- **#22**: `sm validate` / `sm doctor` config validation
- **#23**: Hard reset confirmation prompt with `--force` flag
- **#24**: `--no-color` flag and `NO_COLOR` env var support
- **#25**: Connection groups via `# group:` comment headers
- **#27**: Shell completions (`sm completions bash/zsh`)
- **#30**: `sm add` interactive wizard with input validation
- **#31**: `sm remove <alias>` with confirmation
- **#32**: `timeout` command availability check with fallback
- **#33**: Terminal title input sanitization (strip control chars)
- **#34**: Complete keybinding documentation in README

### Issues NOT included (3 deferred):
- **#26**: Import from `~/.ssh/config` — complex parsing, high risk
- **#28**: Connection history — requires persistent state
- **#29**: Change config delimiter — breaking change, needs migration

## Stats
- `sm`: 1047 → 1622 lines (security + DRY + features)
- `uninstall.sh`: 17 → 122 lines (full rewrite)
- `README.md`: 201 → 249 lines (keybinding docs)
- `.gitignore`: new (21 lines)
- 8 commits, 28 issues resolved
- Codex reviewed and approved at every gate (plan, implementation, test verification)
- `bash -n sm` passes on all commits

## Test plan
- [ ] `sm --help` shows usage
- [ ] `sm --version` shows version
- [ ] `sm list` shows connections with description column
- [ ] `sm test <alias>` tests connectivity
- [ ] `sm validate` checks config
- [ ] `sm edit` opens editor
- [ ] `sm add` wizard with `|` validation
- [ ] `sm remove <alias>` with confirmation
- [ ] `sm reset <alias>` prompts unless `--force`
- [ ] `sm completions bash` outputs valid script
- [ ] `NO_COLOR=1 sm list` shows no ANSI codes
- [ ] Interactive menu: `/` filters, `ESC` clears filter
- [ ] `./uninstall.sh --help` shows usage
- [ ] `echo n | ./uninstall.sh` aborts safely

Resolves #5, #6, #7, #8, #9, #10, #11, #12, #13, #14, #15, #16, #17, #18, #19, #20, #21, #22, #23, #24, #25, #27, #30, #31, #32, #33, #34, #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)